### PR TITLE
Remove isTraitWeakAgainst

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -192,7 +192,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
         if(isTraitEffectiveAgainst(characterTrait, monsterTrait)) {
             traitBonus = traitBonus.add(oneBonus);
         }
-        else if(isTraitWeakAgainst(characterTrait, monsterTrait)) {
+        else if(isTraitEffectiveAgainst(monsterTrait, characterTrait)) {
             traitBonus = traitBonus.sub(oneBonus);
         }
         return traitBonus;
@@ -223,10 +223,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
     function isTraitEffectiveAgainst(uint8 attacker, uint8 defender) public pure returns (bool) {
         return (((attacker + 1) % 4) == defender); // Thanks to Tourist
-    }
-
-    function isTraitWeakAgainst(uint8 attacker, uint8 defender) public pure returns (bool) {
-        return (((defender + 1) % 4) == attacker);
     }
 
     function mintCharacter() public doesNotHaveMoreThanMaxCharacters oncePerBlock(msg.sender) requestPayFromPlayer(mintCharacterFee) {


### PR DESCRIPTION
The isTraitWeakAgainst function is redundant as it simply returns the same response as isTraitEffectiveAgainst with the parameters swapped.  The compiler (solc) suggests that isTraitEffectiveAgainst is slightly more efficient than isTraitWeakAgainst, so keeping the more efficient one.

Output from `solc -gas --optimize cryptoblades.sol` includes:
```
isTraitEffectiveAgainst(uint8,uint8):        411
isTraitWeakAgainst(uint8,uint8):     434
```