### PR TITLE
Simplify getStatCount

### DIFF
--- a/contracts/weapons.sol
+++ b/contracts/weapons.sol
@@ -236,14 +236,10 @@ contract Weapons is Initializable, ERC721Upgradeable, AccessControlUpgradeable {
     }
 
     function getStatCount(uint256 stars) public pure returns (uint8) {
-        uint8 statCount = 1;
-        if(stars == 3) { // 4 star
-            statCount = 2;
-        }
-        else if(stars > 3) { // 5 star and above
-            statCount = 3;
-        }
-        return statCount;
+        // 1-2 star
+        if (stars < 3) return 1;
+        // 3+ star
+        return uint8(stars)-1;
     }
 
     function getProperties(uint256 id) public view returns (uint16) {


### PR DESCRIPTION
Replaces an if branch in getStatCount with a subtraction operation.

Output from `solc -gas --optimize cryptoblades.sol` includes:

Before
```
getStatCount(uint256):       449
```

After
```
getStatCount(uint256):      385
```