### PR TITLE
Simplify getStatMinRoll

### DIFF
--- a/contracts/weapons.sol
+++ b/contracts/weapons.sol
@@ -202,20 +202,16 @@ contract Weapons is Initializable, ERC721Upgradeable, AccessControlUpgradeable {
     }
 
     function getStatMinRoll(uint256 stars) public pure returns (uint16) {
-        uint16 minRoll = uint16(SafeMath.mul(1, 4));
-        if(stars == 1) { // 2 star
-            minRoll = uint16(SafeMath.mul(45, 4));
-        }
-        else if(stars == 2) { // 3 star
-            minRoll = uint16(SafeMath.mul(70, 4));
-        }
-        else if(stars == 3) { // 4 star
-            minRoll = uint16(SafeMath.mul(50, 4));
-        }
-        else if(stars > 3) { // 5 star and above
-            minRoll = uint16(SafeMath.mul(67, 4));
-        }
-        return minRoll;
+        // 1 star
+        if (stars == 0) return 4;
+        // 2 star
+        if (stars == 1) return 180;
+        // 3 star
+        if (stars == 2) return 280;
+        // 4 star
+        if (stars == 3) return 200;
+        // 5+ star
+        return 268;
     }
 
     function getStatMaxRoll(uint256 stars) public pure returns (uint16) {


### PR DESCRIPTION
Replaces some multiplications of constants with the result and two if branches with a pairing of multiplication and addition.

It was difficult to get the compiler to report useful information on gas fees for the original implementation.

Replacing usage of `SafeMath` multiplication solved that issue:
`getStatMinRoll4(uint256):    458`

Replacing the if branches lowered it ~14% from there:
`getStatMinRoll10(uint256):   394`