### PR TITLE
Inline getLevel() into getPower()

### DIFF
--- a/contracts/characters.sol
+++ b/contracts/characters.sol
@@ -113,16 +113,12 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
         emit NewCharacter(tokenID, minter);
     }
 
-    function getLevel(uint256 id) public view returns (uint8) {
-        return tokens[id].level;
-    }
-
     function getRequiredXpForNextLevel(uint8 currentLevel) public view returns (uint16) {
         return uint16(experienceTable[currentLevel]);
     }
 
     function getPower(uint256 id) public view returns (uint24) {
-        return getPowerAtLevel(getLevel(id));
+        return getPowerAtLevel(tokens[id].level);
     }
 
     function getPowerAtLevel(uint8 level) public pure returns (uint24) {


### PR DESCRIPTION
The `getLevel` in characters.sol is only called by `getPower`.  Inlining saves some gas.

Using `solc.exe --gas --optimize characters.sol`...

Before
```
Gas estimation:
construction:
   3595 + 3242600 = 3246195
```

After
```
Gas estimation:
construction:
   3579 + 3231200 = 3234779
```

11416 gas savings