### PR TITLE
Optimize gainXp

### DIFF
--- a/contracts/characters.sol
+++ b/contracts/characters.sol
@@ -117,10 +117,6 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
         return tokens[id].level;
     }
 
-    function getRequiredXpForNextLevel(uint8 currentLevel) public view returns (uint16) {
-        return uint16(experienceTable[currentLevel]);
-    }
-
     function getPower(uint256 id) public view returns (uint24) {
         return getPowerAtLevel(getLevel(id));
     }
@@ -152,13 +148,13 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
         Character storage char = tokens[id];
         if(char.level < 255) {
             uint newXp = char.xp.add(xp);
-            uint requiredToLevel = getRequiredXpForNextLevel(char.level); // technically next level
+            uint requiredToLevel = experienceTable[char.level]; // technically next level
             while(newXp >= requiredToLevel) {
                 newXp = newXp.sub(requiredToLevel);
-                char.level = uint8(char.level.add(1));
+                char.level += 1;
                 emit LevelUp(ownerOf(id), id, char.level);
                 if(char.level < 255)
-                    requiredToLevel = getRequiredXpForNextLevel(char.level);
+                    requiredToLevel = experienceTable[char.level];
                 else
                     newXp = 0;
             }


### PR DESCRIPTION
Improves (decrease) gas usage of gainXp with small adjustments.

Evaluated by using `solc.exe --gas --optimize characters.sol` at observing the output below:
```
Gas estimation:
construction:
```

Original
`3595 + 3242600 = 3246195`

Optimization 1: Inline `getRequiredXpForNextLevel`
`3579 + 3231400 = 3234979`

Optimization 2: Remove casting from `uint16` to `uint`
`3579 + 3229800 = 3233379`

Optimization 3: Simplify `char.level` increment
`3579 + 3226600 = 3230179`

16016 gas savings
