### PR TITLE
Optimize drainStamina

### DIFF
--- a/contracts/characters.sol
+++ b/contracts/characters.sol
@@ -176,13 +176,14 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
 
     function drainStamina(uint256 id, uint8 amount) public restricted returns(bool) {
         if(getStaminaPoints(id) >= amount) {
-            uint64 drainTime = uint64(amount.mul(secondsPerStamina));
+            uint64 newTimestamp = uint64(amount * secondsPerStamina);
             if(isStaminaFull(id)) { // if stamina full, we reset timestamp and drain from that
-                setStaminaTimestamp(id, uint64(now.sub(getStaminaMaxWait()).add(drainTime)));
+                newTimestamp += uint64(now - getStaminaMaxWait());
             }
             else {
-                setStaminaTimestamp(id, uint64(uint256(getStaminaTimestamp(id)).add(drainTime)));
+                newTimestamp += getStaminaTimestamp(id);
             }
+            setStaminaTimestamp(id, newTimestamp);
             return true;
         }
         else {


### PR DESCRIPTION
Gas optimization based on measurement by:
`solc.exe --gas --optimize characters.sol`

These results are from the compiler output below:
```
Gas estimation:
construction:
```

Original
`3595 + 3242600 = 3246195`

Step 1: Use simple binary operators instead of functions
`3587 + 3236800 = 3240387`

Step 2: Remove some casting in second invocation of `setStaminaTimestamp`
`3587 + 3233200 = 3236787`

Step 3: Restructure for single invocation of `setStaminaTimestamp`
`3579 + 3231400 = 3234979`

 11216 gas savings