### PR TITLE
Optimize getStaminaPoints

### DIFF
--- a/contracts/characters.sol
+++ b/contracts/characters.sol
@@ -195,7 +195,7 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
         if(timestamp  > now)
             return 0;
 
-        uint256 points = now.sub(timestamp).div(secondsPerStamina);
+        uint256 points = (now - timestamp) / secondsPerStamina;
         if(points > maxStamina) {
             points = maxStamina;
         }


### PR DESCRIPTION
Replaces function calls with simple binary operators.

Measured with:
`solc.exe --gas --optimize characters.sol`

Before
`3595 + 3242600 = 3246195`

After
`3587 + 3236400 = 3239987`

6208 gas savings
