### PR TITLE
Change getTargetsInternal to private

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -286,7 +286,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     function getTargetsInternal(uint24 playerPower,
         uint64 staminaTimestamp,
         uint256 currentHour
-    ) public pure returns (uint32[4] memory) {
+    ) private pure returns (uint32[4] memory) {
         // 4 targets, roll powers based on character + weapon power
         // trait bonuses not accounted for
         // targets expire on the hour


### PR DESCRIPTION
This function should be private in terms of exposure and making it private also saves a compiler-estimated 13417 gas.