### PR TITLE
Band the win rates instead of displaying percentage

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -244,9 +244,9 @@ export default {
         rollingTotal = (1 - rollingTotal);
       }
       if (rollingTotal <= 0.30) return 'Unlikely';
-      else if (rollingTotal <= 0.50) return 'Possible';
-      else if (rollingTotal <= 0.70) return 'Likely';
-      else return 'Very Likely';
+      if (rollingTotal <= 0.50) return 'Possible';
+      if (rollingTotal <= 0.70) return 'Likely';
+      return 'Very Likely';
     },
     getElementAdvantage(playerElement, enemyElement){
       if (((playerElement+1)%4) === enemyElement)


### PR DESCRIPTION
Banded win rates instead of revealing exact percents. Bands are:
< 30% - Unlikely
< 50% - Possible
< 70% - Likely
> 70% - Very Likely
![image](https://user-images.githubusercontent.com/6930354/122845351-8b2e5780-d2d1-11eb-974d-a72f89cb3e95.png)
