### PR TITLE
Simplify getBonusPower

### DIFF
--- a/contracts/weapons.sol
+++ b/contracts/weapons.sol
@@ -446,12 +446,7 @@ contract Weapons is Initializable, ERC721Upgradeable, AccessControlUpgradeable, 
 
     function getBonusPower(uint256 id) public view returns (uint24) {
         Weapon storage wep = tokens[id];
-        WeaponBurnPoints storage wbp = burnPoints[id];
-        return uint24(lowStarBurnPowerPerPoint.mul(wbp.lowStarBurnPoints)
-            .add(fourStarBurnPowerPerPoint.mul(wbp.fourStarBurnPoints))
-            .add(fiveStarBurnPowerPerPoint.mul(wbp.fiveStarBurnPoints))
-            .add(uint256(15).mul(wep.level)) // TEMP: UNTIL WE IMPLEMENT WEAPON LEVELS
-        );
+        return getBonusPowerForFight(id, wep.level);
     }
 
     function getBonusPowerForFight(uint256 id, uint8 level) public view returns (uint24) {


### PR DESCRIPTION
Reasons for this change:
1. Readability
2. Simplicity
3. Maintainability
4. Performance

Using `solc.exe --gas --optimize characters.sol`, 3409 estimated gas savings.

