### PR TITLE
Optimize performFight

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -204,15 +204,14 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
         uint16 xp = getXpGainForFight(playerFightPower, targetPower);
         uint256 tokens = usdToSkill(getTokenGainForFight(targetPower));
 
-        if(playerRoll >= monsterRoll) {
-            tokenRewards[msg.sender] += tokens;
-            xpRewards[char] += xp;
+        if(playerRoll < monsterRoll) {
+            tokens = 0;
+            xp = 0;
         }
-        else {
-            // this may seem dumb but we want to avoid guessing the outcome based on gas estimates!
-            tokenRewards[msg.sender] += 0;
-            xpRewards[char] += 0;
-        }
+
+        // this may seem dumb but we want to avoid guessing the outcome based on gas estimates!
+        tokenRewards[msg.sender] += tokens;
+        xpRewards[char] += xp;
 
         emit FightOutcome(msg.sender, char, wep, (targetPower | ((uint32(traitsCWE) << 8) & 0xFF000000)), playerRoll, monsterRoll, xp, tokens);
     }


### PR DESCRIPTION
Using `solc.exe --gas --optimize cryptoblades.sol`, 26834 estimated gas savings.

Optimization 1 (25234 estimated gas savings):
Replace SafeMath with native operators.

Optimization 2 (1600 estimated gas savings):
Restructure if branching to use += operator pair only once.