### PR TITLE
Expand ViewLinks click range to entire interact area

### DIFF
--- a/frontend/src/components/ViewLinks.vue
+++ b/frontend/src/components/ViewLinks.vue
@@ -43,5 +43,10 @@ export default {
 <style scoped>
 a {
   font-weight: bold;
+  display: inline-block;
+  position: relative;
+  z-index: 1;
+  padding: 5px;
+  margin: -5px;
 }
 </style>


### PR DESCRIPTION
Closes https://github.com/CryptoBlades/cryptoblades/issues/55

There may be a better approach using bootstrap, but editing the CSS on the a-tag in ViewLinks.vue makes it so that the entire "interact" range(where the hand shows up) is now clickable. 

Would post a screenshot of where I'm clicking, but snipping tool won't capture my cursor. I really need to set up snagit or something...