### PR TITLE
Change guaranteed shortcuts to bands instead of 100/0

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -221,8 +221,8 @@ export default {
       const enemyRange = (enemyMax - enemyMin);
       let rollingTotal = 0;
       // shortcut: if it is impossible for one side to win, just say so
-      if (playerMin > enemyMax) return 100;
-      if (playerMax < enemyMin) return 0;
+      if (playerMin > enemyMax) return 'Very Likely';
+      if (playerMax < enemyMin) return 'Unlikely';
 
       // case 1: player power is higher than enemy power
       if (playerMin >= enemyMin){


### PR DESCRIPTION
Shortcuts for win rate were still returning 100/0 for guaranteed win/loss, updated those to use the band values instead. 