### PR TITLE
Clear invalid weapon from selection on account change

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -191,6 +191,10 @@ export default {
 
   watch: {
     async selections([characterId, weaponId]) {
+      if(!this.ownWeapons.find((weapon) => weapon.id === weaponId)) {
+        console.log('clearing weapon');
+        this.selectedWeaponId = null;
+      }
       await this.fetchTargets({ characterId, weaponId });
     },
   },


### PR DESCRIPTION
Closes https://github.com/CryptoBlades/cryptoblades/issues/61

Updated the watch on selections([characterId, weaponId]) so that if the account changes (which changes the default character to slot 0 of the new account) it sees the weapon is no longer valid and nulls it out.

After switching accounts with a sword selected:
![image](https://user-images.githubusercontent.com/6930354/123017733-31925f80-d39b-11eb-9ace-b3722d602dcf.png)
