### PR TITLE
Validate targets on attack, lock attack buttons when waiting for results

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -97,7 +97,7 @@
                 :mainText="`Fight!`"
                 :subText="`Power ${e.power}\nChance of Victory: ${getWinChance(e.power)}`"
                 v-tooltip="'Cost 40 stamina'"
-                :disabled="timeMinutes === 59 && timeSeconds >= 30"
+                :disabled="(timeMinutes === 59 && timeSeconds >= 30) || isLoadingTargets"
                 @click="onClickEncounter(e)"
               />
 
@@ -192,7 +192,6 @@ export default {
   watch: {
     async selections([characterId, weaponId]) {
       if(!this.ownWeapons.find((weapon) => weapon.id === weaponId)) {
-        console.log('clearing weapon');
         this.selectedWeaponId = null;
       }
       await this.fetchTargets({ characterId, weaponId });
@@ -265,6 +264,12 @@ export default {
         return;
       }
 
+      // Force a quick refresh of targets
+      await this.fetchTargets({ characterId: this.currentCharacterId, weaponId: this.selectedWeaponId });
+      // If the targets list no longer contains the chosen target, return so a new target can be chosen
+      if (!this.targets.find((target) => target.original === targetToFight.original)) {
+        return;
+      }
       try {
         this.waitingResults = true;
         const results = await this.doEncounter({


### PR DESCRIPTION
Causes the fight button to refresh targets and make sure the target is still valid, also blocks out the combat buttons while waiting for the combat results. Also apparently removed a console.log() I accidentally left in earlier too.

Closes https://github.com/CryptoBlades/cryptoblades/issues/52
(and addresses Omni's comment on that one) and provides one layer of protection against https://github.com/CryptoBlades/cryptoblades/issues/17 but that one can use a cleaner solution too.
![1 - button lock while confirming](https://user-images.githubusercontent.com/6930354/123029986-06663b00-d3b0-11eb-94a0-63a6876e108f.PNG)
