### PR TITLE
Don't wait for results until after encounter committed

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -266,12 +266,12 @@ export default {
       }
 
       try {
-        this.waitingResults = true;
         const results = await this.doEncounter({
           characterId: this.currentCharacterId,
           weaponId: this.selectedWeaponId,
           targetString: targetToFight.original,
         });
+        this.waitingResults = true;
         /*const success = results[0];
         const playerRoll = results[1];
         const enemyRoll = results[2];


### PR DESCRIPTION
Omni's fix to prevent the "Waiting for fight results..." from showing up when rejecting the attack in Metamask. Again, Omni's fix, but I'm not sure if he was going to submit or not so I'm submitting on his behalf (and please reject this if he does submit it)
before:
![before, loop](https://user-images.githubusercontent.com/6930354/123030685-2d713c80-d3b1-11eb-9b8c-df2fb9e5ff87.PNG)
after:
![after](https://user-images.githubusercontent.com/6930354/123030692-2fd39680-d3b1-11eb-8b31-50b2133b6cdb.PNG)
