### PR TITLE
Move localization to display, use number

### DIFF
--- a/frontend/src/components/smart/CharacterDisplay.vue
+++ b/frontend/src/components/smart/CharacterDisplay.vue
@@ -25,7 +25,7 @@
       }}</span>
       <span v-if="isLoadingCharacter" class="name bold">Loading...</span>
       <span v-if="!isLoadingCharacter" class="subtext">
-        Level {{ currentCharacter.level + 1 }} ({{ currentCharacter.xp }} / {{RequiredXp(currentCharacter.level)}} XP)
+        Level {{ currentCharacter.level + 1 }} ({{ currentCharacter.xp }} / {{RequiredXp(currentCharacter.level).toLocaleString()}} XP)
       </span>
       <span v-if="!isLoadingCharacter" class="subtext">
         Power: {{CharacterPower(currentCharacter.level).toLocaleString()}}

--- a/frontend/src/interfaces/Character.ts
+++ b/frontend/src/interfaces/Character.ts
@@ -35,5 +35,5 @@ export function RequiredXp(level: number) {
       xp += Math.floor((i-14) + 1);
     }
   }
-  return xp.toLocaleString();
+  return xp;
 }

--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -97,7 +97,7 @@
                 :mainText="`Fight!`"
                 :subText="`Power ${e.power}\nChance of Victory: ${getWinChance(e.power, e.trait)}`"
                 v-tooltip="'Cost 40 stamina'"
-                :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults"
+                :disabled="(timeMinutes === 59 && timeSeconds >= 30) || isLoadingTargets"
                 @click="onClickEncounter(e)"
               />
 
@@ -211,7 +211,6 @@ export default {
     },
     getWinChance(enemyPower, enemyElement) {
       const characterPower = CharacterPower(this.currentCharacter.level);
-      console.log(characterPower);
       const playerElement = parseInt(this.currentCharacter.trait, 10);
       const selectedWeapon = this.ownWeapons.find((weapon) => weapon.id ===this.selectedWeaponId);
       const weaponElement = parseInt(WeaponElement[selectedWeapon.element], 10);


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?
n/a, changes are only for people whose localization uses non-comma symbols as the thousands separator

### PR Description

Moves localization out of the Character functions and into CharacterDisplay.vue. Only the CombatPower was needed for this, but I moved XP as well to be consistent across all of Character's methods.

Also accidentally included a fix for the combat button lockout when waiting for results, let me know if I should pull that into another PR and I can.