### PR TITLE
Use waitingResults to block instead of isLoadingTargets

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -98,7 +98,7 @@
                 :subText="`Power: ${e.power}`"
 				:subText2="`Chance to Win: ${getWinChance(e.power, e.trait)}`"
                 v-tooltip="'Cost 40 stamina'"
-                :disabled="(timeMinutes === 59 && timeSeconds >= 30) || isLoadingTargets"
+                :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults"
                 @click="onClickEncounter(e)"
               />
 


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?
Old: Combat buttons still clickable while engaged in combat, allowing the user to double-send two fights with the second being invalid
![image](https://user-images.githubusercontent.com/6930354/123526431-d9fb3900-d6a5-11eb-979e-c45cfeda2530.png)
New: combat buttons properly disabled:
![image](https://user-images.githubusercontent.com/6930354/123526465-19c22080-d6a6-11eb-90f8-c259dee5b113.png)
### New Feature Submissions

* [x] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
Fix for my previous PR, https://github.com/CryptoBlades/cryptoblades/pull/81
### PR Description

On my previous PR I had the test case set up incorrectly (due to near-instant block time on Ganache, I had to use a blocking statement in the combat loop) and used the wrong loading state to block the combat buttons. 