### PR TITLE
Level 41 character still show with 31-40 filter?

### DIFF
--- a/frontend/src/components/smart/CharacterList.vue
+++ b/frontend/src/components/smart/CharacterList.vue
@@ -99,7 +99,7 @@ export default {
         }
 
         if(this.levelFilter) {
-          items = items.filter(x => x.level >= this.levelFilter - 1 && x.level <= this.levelFilter + 9);
+          items = items.filter(x => x.level >= this.levelFilter - 1 && x.level <= this.levelFilter + 8);
         }
 
         if(this.showLimit > 0 && items.length > this.showLimit) {


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
https://github.com/CryptoBlades/cryptoblades/issues/121
### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Yes, the range was 11 levels from x - 1 to x + 9, now it's 10 levels (to x + 8).