### PR TITLE
Cleans up Combat Results (Take 2!)

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -7,22 +7,21 @@
 
       <div class="row">
         <div class="col">
-          <div class="payout-info">{{getPayoutString()}}</div>
+          <div class="payout-info">{{ getPayoutString() }}</div>
         </div>
       </div>
 
       <div class="row">
         <div class="col text-center">
           <div class="combat-hints">
-            <span class="fire-icon" /> »
-            <span class="earth-icon" /> »
-            <span class="lightning-icon" /> »
-            <span class="water-icon" /> »
+            <span class="fire-icon" /> » <span class="earth-icon" /> » <span class="lightning-icon" /> » <span class="water-icon" /> »
             <span class="fire-icon" />
 
-            <Hint text="The elements affect power:<br>
+            <Hint
+              text="The elements affect power:<br>
               <br>Character vs Enemy: bonus or penalty as shown above
-              <br>Character and Weapon match gives bonus" />
+              <br>Character and Weapon match gives bonus"
+            />
           </div>
         </div>
       </div>
@@ -35,23 +34,16 @@
 
       <div class="row">
         <div class="col">
-          <div class="message-box" v-if="!currentCharacter">
-            You need to select a character to do battle.
-          </div>
+          <div class="message-box" v-if="!currentCharacter">You need to select a character to do battle.</div>
 
-          <div class="message-box" v-if="currentCharacter && currentCharacterStamina < 40">
-            You need 40 stamina to do battle.
-          </div>
+          <div class="message-box" v-if="currentCharacter && currentCharacterStamina < 40">You need 40 stamina to do battle.</div>
 
-          <div class="message-box" v-if="timeMinutes === 59 && timeSeconds >= 30">
-            You cannot do battle during the last 30 seconds of the hour. Stand fast!
-          </div>
+          <div class="message-box" v-if="timeMinutes === 59 && timeSeconds >= 30">You cannot do battle during the last 30 seconds of the hour. Stand fast!</div>
         </div>
       </div>
 
       <div class="row" v-if="currentCharacterStamina >= 40">
         <div class="col">
-
           <div class="row">
             <div class="col">
               <div class="waiting" v-if="waitingResults" margin="auto">
@@ -64,39 +56,34 @@
           <div class="row">
             <div class="col">
               <div class="header-row">
-                <Hint text="Your weapon multiplies your power<br>
+                <Hint
+                  text="Your weapon multiplies your power<br>
                   <br>+Stats determine the multiplier
-                  <br>Stat element match with character gives greater bonus" />
+                  <br>Stat element match with character gives greater bonus"
+                />
                 <h1>Choose a weapon</h1>
 
-                <b-button
-                  v-if="selectedWeaponId"
-                  variant="primary"
-                  class="ml-3"
-                  @click="selectedWeaponId = null">
-                  Choose New Weapon
-                </b-button>
+                <b-button v-if="selectedWeaponId" variant="primary" class="ml-3" @click="selectedWeaponId = null"> Choose New Weapon </b-button>
               </div>
 
-              <weapon-grid v-if="!selectedWeaponId"
-                           v-model="selectedWeaponId" />
+              <weapon-grid v-if="!selectedWeaponId" v-model="selectedWeaponId" />
             </div>
           </div>
 
           <div class="row mb-3" v-if="targets.length > 0">
             <div class="col-md-3 col-sm-12 col-xs-12 encounter text-center d-flex flex-column justify-content-center" v-for="(e, i) in targets" :key="i">
-              <img class="mr-auto ml-auto" :src="getEnemyArt(e.power)" alt="Enemy">
+              <img class="mr-auto ml-auto" :src="getEnemyArt(e.power)" alt="Enemy" />
 
               <div class="encounter-element">
-                <span :class="getCharacterTrait(e.trait).toLowerCase()">{{getCharacterTrait(e.trait)}}</span>
-                <span :class="getCharacterTrait(e.trait).toLowerCase()+'-icon'" />
+                <span :class="getCharacterTrait(e.trait).toLowerCase()">{{ getCharacterTrait(e.trait) }}</span>
+                <span :class="getCharacterTrait(e.trait).toLowerCase() + '-icon'" />
               </div>
 
               <big-button
                 class="encounter-button"
                 :mainText="`Fight!`"
                 :subText="`Power: ${e.power}`"
-				:subText2="`Chance to Win: ${getWinChance(e.power, e.trait)}`"
+                :subText2="`Chance to Win: ${getWinChance(e.power, e.trait)}`"
                 v-tooltip="'Cost 40 stamina'"
                 :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults"
                 @click="onClickEncounter(e)"
@@ -105,22 +92,16 @@
               <p v-if="isLoadingTargets">Loading...</p>
             </div>
           </div>
-
         </div>
       </div>
 
-      <div>
-      </div>
+      <div></div>
     </div>
 
     <div class="blank-slate" v-if="ownWeapons.length === 0 || ownCharacters.length === 0">
-      <div v-if="ownWeapons.length === 0">
-        You do not currently have any weapons. You can forge one at the Blacksmith.
-      </div>
+      <div v-if="ownWeapons.length === 0">You do not currently have any weapons. You can forge one at the Blacksmith.</div>
 
-      <div v-if="ownCharacters.length === 0">
-        You do not currently have any characters. You can recruit one at the Plaza.
-      </div>
+      <div v-if="ownCharacters.length === 0">You do not currently have any characters. You can recruit one at the Plaza.</div>
     </div>
   </div>
 </template>
@@ -153,9 +134,9 @@ export default {
     };
   },
 
-  created(){
-    this.intervalSeconds = setInterval(() => this.timeSeconds = new Date().getSeconds(), 5000);
-    this.intervalMinutes = setInterval(() => this.timeMinutes = new Date().getMinutes(), 20000);
+  created() {
+    this.intervalSeconds = setInterval(() => (this.timeSeconds = new Date().getSeconds()), 5000);
+    this.intervalMinutes = setInterval(() => (this.timeMinutes = new Date().getMinutes()), 20000);
   },
 
   computed: {
@@ -171,31 +152,33 @@ export default {
     ]),
 
     targets() {
-      return this.getTargetsByCharacterIdAndWeaponId(
-        this.currentCharacterId,
-        this.selectedWeaponId
-      );
+      return this.getTargetsByCharacterIdAndWeaponId(this.currentCharacterId, this.selectedWeaponId);
     },
 
     isLoadingTargets() {
-      return (
-        this.targets.length === 0 &&
-        this.currentCharacterId &&
-        this.selectedWeaponId
-      );
+      return this.targets.length === 0 && this.currentCharacterId && this.selectedWeaponId;
     },
 
     selections() {
       return [this.currentCharacterId, this.selectedWeaponId];
     },
+
+    updateResults() {
+      return [this.fightResults, this.error];
+    },
   },
 
   watch: {
     async selections([characterId, weaponId]) {
-      if(!this.ownWeapons.find((weapon) => weapon.id === weaponId)) {
+      if (!this.ownWeapons.find((weapon) => weapon.id === weaponId)) {
         this.selectedWeaponId = null;
       }
       await this.fetchTargets({ characterId, weaponId });
+    },
+
+    async updateResults([fightResults, error]) {
+      this.resultsAvailable = fightResults !== null;
+      this.waitingResults = fightResults === null && error === null;
     },
   },
 
@@ -206,58 +189,56 @@ export default {
       return CharacterTrait[trait];
     },
     getPayoutString() {
-      return 'Earnings on victory: '
-        +this.formattedSkill(this.fightGasOffset) + ' gas offset + '
-        +this.formattedSkill(this.fightBaseline)+' per 1000 power';
+      return (
+        'Earnings on victory: ' + this.formattedSkill(this.fightGasOffset) + ' gas offset + ' + this.formattedSkill(this.fightBaseline) + ' per 1000 power'
+      );
     },
     getWinChance(enemyPower, enemyElement) {
       const characterPower = CharacterPower(this.currentCharacter.level);
       const playerElement = parseInt(this.currentCharacter.trait, 10);
-      const selectedWeapon = this.ownWeapons.find((weapon) => weapon.id ===this.selectedWeaponId);
+      const selectedWeapon = this.ownWeapons.find((weapon) => weapon.id === this.selectedWeaponId);
       const weaponElement = parseInt(WeaponElement[selectedWeapon.element], 10);
       const weaponMultiplier = GetTotalMultiplierForTrait(selectedWeapon, playerElement);
-      const totalPower = ((characterPower * weaponMultiplier) + selectedWeapon.bonusPower);
+      const totalPower = characterPower * weaponMultiplier + selectedWeapon.bonusPower;
       const totalMultiplier = 1 + 0.075 * ((weaponElement === playerElement ? 1 : 0) + this.getElementAdvantage(playerElement, enemyElement));
-      const playerMin = (totalPower * totalMultiplier) * 0.9;
-      const playerMax = (totalPower * totalMultiplier) * 1.1;
-      const playerRange = (playerMax - playerMin);
-      const enemyMin = (enemyPower * 0.9);
-      const enemyMax = (enemyPower * 1.1);
-      const enemyRange = (enemyMax - enemyMin);
+      const playerMin = totalPower * totalMultiplier * 0.9;
+      const playerMax = totalPower * totalMultiplier * 1.1;
+      const playerRange = playerMax - playerMin;
+      const enemyMin = enemyPower * 0.9;
+      const enemyMax = enemyPower * 1.1;
+      const enemyRange = enemyMax - enemyMin;
       let rollingTotal = 0;
       // shortcut: if it is impossible for one side to win, just say so
       if (playerMin > enemyMax) return 'Very Likely';
       if (playerMax < enemyMin) return 'Unlikely';
 
       // case 1: player power is higher than enemy power
-      if (playerMin >= enemyMin){
+      if (playerMin >= enemyMin) {
         // case 1: enemy roll is lower than player's minimum
-        rollingTotal = ((playerMin - enemyMin)/enemyRange);
+        rollingTotal = (playerMin - enemyMin) / enemyRange;
         // case 2: 1 is not true, and player roll is higher than enemy maximum
-        rollingTotal += ((1-rollingTotal) * ((playerMax-enemyMax)/playerRange));
+        rollingTotal += (1 - rollingTotal) * ((playerMax - enemyMax) / playerRange);
         // case 3: 1 and 2 are not true, both values are in the overlap range. Since values are basically continuous, we assume 50%
-        rollingTotal += ((1-rollingTotal) * 0.5);
+        rollingTotal += (1 - rollingTotal) * 0.5;
       } // otherwise, enemy power is higher
       else {
         // case 1: player rolls below enemy minimum
-        rollingTotal = ((enemyMin - playerMin) / playerRange);
+        rollingTotal = (enemyMin - playerMin) / playerRange;
         // case 2: enemy rolls above player maximum
-        rollingTotal += ((1 - rollingTotal) * ((enemyMax - playerMax)/enemyRange));
+        rollingTotal += (1 - rollingTotal) * ((enemyMax - playerMax) / enemyRange);
         // case 3: 1 and 2 are not true, both values are in the overlap range
-        rollingTotal += ((1 - rollingTotal) * 0.5);
+        rollingTotal += (1 - rollingTotal) * 0.5;
         //since this is chance the enemy wins, we negate it
-        rollingTotal = (1 - rollingTotal);
+        rollingTotal = 1 - rollingTotal;
       }
-      if (rollingTotal <= 0.30) return 'Unlikely';
-      if (rollingTotal <= 0.50) return 'Possible';
-      if (rollingTotal <= 0.70) return 'Likely';
+      if (rollingTotal <= 0.3) return 'Unlikely';
+      if (rollingTotal <= 0.5) return 'Possible';
+      if (rollingTotal <= 0.7) return 'Likely';
       return 'Very Likely';
     },
-    getElementAdvantage(playerElement, enemyElement){
-      if (((playerElement+1)%4) === enemyElement)
-        return 1;
-      if (((enemyElement+1)%4) === playerElement)
-        return -1;
+    getElementAdvantage(playerElement, enemyElement) {
+      if ((playerElement + 1) % 4 === enemyElement) return 1;
+      if ((enemyElement + 1) % 4 === playerElement) return -1;
       return 0;
     },
     async onClickEncounter(targetToFight) {
@@ -271,35 +252,23 @@ export default {
       if (!this.targets.find((target) => target.original === targetToFight.original)) {
         return;
       }
+
+      this.fightResults = null;
+      this.error = null;
+      this.waitingResults = true;
+
       try {
-        this.waitingResults = true;
         const results = await this.doEncounter({
           characterId: this.currentCharacterId,
           weaponId: this.selectedWeaponId,
           targetString: targetToFight.original,
         });
-        /*const success = results[0];
-        const playerRoll = results[1];
-        const enemyRoll = results[2];
-        const xpGain = results[3];
-        const skillGain = results[4];*/
+
         this.fightResults = results;
 
-        this.resultsAvailable = true;
-        // results are passed to the CombatResults element
-        this.waitingResults = false;
+        await this.fetchFightRewardSkill();
+        await this.fetchFightRewardXp();
 
-        this.fetchFightRewardSkill();
-        this.fetchFightRewardXp();
-
-        /*if (success) {
-          alert('Battle succeeded! You rolled '+playerRoll
-          +' and the enemy rolled '+enemyRoll
-          +', you gain '+xpGain+'xp and '+skillGain+' SKILL');
-        } else {
-          alert('Battle failed... You rolled '+playerRoll
-          +' and the enemy rolled '+enemyRoll);
-        }*/
         this.error = null;
       } catch (e) {
         console.error(e);
@@ -313,7 +282,6 @@ export default {
   },
 
   components: {
-    // Character,
     BigButton,
     WeaponGrid,
     Hint,
@@ -323,7 +291,6 @@ export default {
 </script>
 
 <style scoped>
-
 .encounter img {
   max-width: 15vw;
 }
@@ -387,8 +354,7 @@ export default {
   font-size: 2em;
 }
 
-div.encounter.text-center{
+div.encounter.text-center {
   flex-basis: auto !important;
 }
-
 </style>


### PR DESCRIPTION
All Submissions
Can you post a screenshot of your changes (if applicable)?
Not in this case.

New Feature Submissions
Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
Yes, PR Don't wait for results until after encounter committed #82 can be closed with this.

PR Description
Clears "Waiting for results" message on combat end and on wallet/transaction error.
Clears Fight Results message on new target selection.
Clears error message on new target selection.
General code cleanup (Prettier)