### PR TITLE
15 decorate unclaimed

### DIFF
--- a/frontend/src/components/smart/ClaimRewardsBar.vue
+++ b/frontend/src/components/smart/ClaimRewardsBar.vue
@@ -19,7 +19,7 @@
       :disabled="!canClaimXp"
       @click="onClaimXp">
 
-        <strong>XP</strong> {{ formattedXpRewards }}
+        <div v-html="`<strong>XP</strong> ${formattedXpRewards}`"></div>
     </b-nav-item>
   </b-navbar>
 </template>
@@ -32,6 +32,8 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import BN from 'bignumber.js';
 import Web3 from 'web3';
 import { getCharacterNameFromSeed } from '../../character-name';
+import { RequiredXp } from '../../interfaces';
+
 
 Vue.use(BootstrapVueIcons);
 
@@ -39,6 +41,7 @@ interface StoreMappedState {
   skillRewards: string;
   xpRewards: Record<string, string>;
   ownedCharacterIds: string[];
+  currentCharacterId: number
 }
 
 interface StoreMappedActions {
@@ -48,7 +51,7 @@ interface StoreMappedActions {
 
 export default Vue.extend({
   computed: {
-    ...(mapState(['skillRewards', 'xpRewards', 'ownedCharacterIds']) as Accessors<StoreMappedState>),
+    ...(mapState(['skillRewards', 'xpRewards', 'ownedCharacterIds', 'currentCharacterId']) as Accessors<StoreMappedState>),
     ...(mapGetters(['ownCharacters'])),
 
     formattedSkillReward(): string {
@@ -63,7 +66,11 @@ export default Vue.extend({
     formattedXpRewards(): string {
       return this.xpRewardsForOwnedCharacters.map((xp, i) => {
         if(!this.ownCharacters[i]) return `${xp}`;
-        return `${getCharacterNameFromSeed(this.ownCharacters[i].id)} ${xp}`;
+        return  `${this.ownCharacters[i].id === this.currentCharacterId ? '<b>' : ''}` +
+                `${(this.ownCharacters[i].xp + this.xpRewards[this.ownCharacters[i].id]) as any > RequiredXp(this.ownCharacters[i].level) ? '<u>' : ''}` +
+                `${getCharacterNameFromSeed(this.ownCharacters[i].id)} ${xp}` +
+                `${(this.ownCharacters[i].xp + this.xpRewards[this.ownCharacters[i].id]) as any > RequiredXp(this.ownCharacters[i].level) ? '</u>' : ''}` +
+                `${this.ownCharacters[i].id === this.currentCharacterId ? '</b>' : ''}`;
       }).join(', ');
     },
 

--- a/frontend/src/components/smart/ClaimRewardsBar.vue
+++ b/frontend/src/components/smart/ClaimRewardsBar.vue
@@ -40,8 +40,7 @@ Vue.use(BootstrapVueIcons);
 interface StoreMappedState {
   skillRewards: string;
   xpRewards: Record<string, string>;
-  ownedCharacterIds: string[];
-  currentCharacterId: number
+  ownedCharacterIds: string[]
 }
 
 interface StoreMappedActions {
@@ -51,8 +50,8 @@ interface StoreMappedActions {
 
 export default Vue.extend({
   computed: {
-    ...(mapState(['skillRewards', 'xpRewards', 'ownedCharacterIds', 'currentCharacterId']) as Accessors<StoreMappedState>),
-    ...(mapGetters(['ownCharacters'])),
+    ...(mapState(['skillRewards', 'xpRewards', 'ownedCharacterIds']) as Accessors<StoreMappedState>),
+    ...(mapGetters(['ownCharacters', 'currentCharacter'])),
 
     formattedSkillReward(): string {
       const skillRewards = Web3.utils.fromWei(this.skillRewards, 'ether');
@@ -66,11 +65,11 @@ export default Vue.extend({
     formattedXpRewards(): string {
       return this.xpRewardsForOwnedCharacters.map((xp, i) => {
         if(!this.ownCharacters[i]) return `${xp}`;
-        return  `${this.ownCharacters[i].id === this.currentCharacterId ? '<b>' : ''}` +
+        return  `${this.ownCharacters[i].id === this.currentCharacter.id ? '<b>' : ''}` +
                 `${(this.ownCharacters[i].xp + this.xpRewards[this.ownCharacters[i].id]) as any > RequiredXp(this.ownCharacters[i].level) ? '<u>' : ''}` +
                 `${getCharacterNameFromSeed(this.ownCharacters[i].id)} ${xp}` +
                 `${(this.ownCharacters[i].xp + this.xpRewards[this.ownCharacters[i].id]) as any > RequiredXp(this.ownCharacters[i].level) ? '</u>' : ''}` +
-                `${this.ownCharacters[i].id === this.currentCharacterId ? '</b>' : ''}`;
+                `${this.ownCharacters[i].id === this.currentCharacter.id ? '</b>' : ''}`;
       }).join(', ');
     },
 


### PR DESCRIPTION
### All Submissions
Addresses https://github.com/CryptoBlades/cryptoblades/issues/15

* [x] Can you post a screenshot of your changes (if applicable)?
![image](https://user-images.githubusercontent.com/6930354/123739332-783cf980-d874-11eb-8226-c44ae4446fe8.png)

### PR Description

The current character is bolded on the claim list, and any characters ready to level up are underlined. This formatting is chosen to be consistent with the changes in 40; in 40, underlining was chosen to denote "character ready to level up" because bold was a little too subtle.