### PR TITLE
Staking unclaimed UX is confusing

### DIFF
--- a/frontend/src/components/smart/Staking.vue
+++ b/frontend/src/components/smart/Staking.vue
@@ -218,7 +218,7 @@ export default {
     unlockTimeLeftInternal() { return this.stakeData.unlockTimeLeft; },
 
     stakingTokenName() {
-      return this.stakeType === 'skill' ? 'SKILL' : 'SKILL-WBNB';
+      return this.stakeType === 'skill' || this.stakeType === 'skill2' ? 'SKILL' : 'SKILL-WBNB';
     },
 
     minimumStakeTimeFormatted() {


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
https://github.com/CryptoBlades/cryptoblades/issues/247
### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Instead of screenshot... (different staking options on local, didn't know how to change that to be same as main)
There's an object in store.ts (skill2 is the new staking option):
```
staking: {
  skill: { ...defaultStakeState },
  skill2: { ...defaultStakeState },
  lp: { ...defaultStakeState },
  lp2: { ...defaultStakeState }
},
```
which is used in Staking.vue (did not cover skill2 option before):
```
stakingTokenName() {
  return this.stakeType === 'skill' || this.stakeType === 'skill2' ? 'SKILL' : 'SKILL-WBNB';
},
```
stakingTokenName is what is displayed in the panel and what caused confusion.