### PR TITLE
Visualize to select BSC network when BSC is not selected in MetaMask

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -279,7 +279,7 @@ export default {
 
     if (this.hideWalletWarning) {
       this.$dialog.notify.warning(
-        'You have Hidden the Wallet Warning and are on the wrong network. If this was not your intention, please change networks or disable the option.',
+        'You have hidden the wallet warning and are on the wrong network. If this was not your intention, please change networks or disable the option.',
         {
           timeout: 0,
         },

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -276,6 +276,15 @@ export default {
         });
       }
     });
+
+    if (this.hideWalletWarning) {
+      this.$dialog.notify.warning(
+        'You have Hidden the Wallet Warning and are on the wrong network. If this was not your intention, please change networks or disable the option.',
+        {
+          timeout: 0,
+        },
+      );
+    }
   },
 
   async created() {
@@ -461,7 +470,8 @@ button.close {
   border-radius: 0.1em !important;
 }
 
-.btn.disabled, .btn:disabled {
+.btn.disabled,
+.btn:disabled {
   cursor: auto;
 }
 


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?
![msedge_TLpKN0b4wP](https://user-images.githubusercontent.com/7065115/125499374-142ac3d2-b386-418f-bb94-0af36afdddfd.png)

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
Closes #256 

### PR Description

Adds a dialog box that catches when users would normally get the fullscreen warning if they have it disabled. Dialog box does not interrupt clicks or navigation, so user is informed without being prohibited.