### PR TITLE
New sqrt payout curve

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -76,6 +76,15 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
         stakeFromGameImpl = _stakeFromGame;
     }
 
+    function migrateTo_7dd2a56() external {
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not admin");
+
+        // numbers given for the curves were $4.3-aligned so they need to be multiplied
+        // additional accuracy may be in order for the setter functions for these
+        fightRewardGasOffset = ABDKMath64x64.divu(23177, 100000); // 0.0539 x 4.3
+        fightRewardBaseline = ABDKMath64x64.divu(344, 1000); // 0.08 x 4.3
+    }
+
     // config vars
     uint characterLimit;
     uint8 staminaCostFight;

--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -284,13 +284,16 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     }
 
     function getTokenGainForFight(uint24 monsterPower) internal view returns (int128) {
-        return ABDKMath64x64.add(
-            // Performance optimization: 1000 = getPowerAtLevel(0)
-            ABDKMath64x64.divu(monsterPower, 1000).mul(fightRewardBaseline),
-            fightRewardGasOffset
+        return fightRewardGasOffset.add(
+            fightRewardBaseline.mul(
+                ABDKMath64x64.sqrt(
+                    // Performance optimization: 1000 = getPowerAtLevel(0)
+                    ABDKMath64x64.divu(monsterPower, 1000)
+                )
+            )
         );
     }
-
+    
     function getXpGainForFight(uint24 playerPower, uint24 monsterPower) internal view returns (uint16) {
         return uint16(ABDKMath64x64.divu(monsterPower, playerPower).mulu(fightXpGain));
     }

--- a/migrations/39_sqrt_payout_curve.js
+++ b/migrations/39_sqrt_payout_curve.js
@@ -1,0 +1,8 @@
+const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+
+const CryptoBlades = artifacts.require("CryptoBlades");
+
+module.exports = async function (deployer, network, accounts) {
+  const game = await upgradeProxy(CryptoBlades.address, CryptoBlades, { deployer });
+  await game.migrateTo_7dd2a56(skillStakingRewards.address);
+};


### PR DESCRIPTION
Adds the new payout curve as discussed by the math team,
comes a migration file to avoid brief payout anomalies after deploy (optional)
(may need better accuracy on the params for the setter functions)

Expected gas cost increase of fights: ~786 (very negligible, may cost a few cents over the course of a day)