### PR TITLE
False "very likely win" fixed

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -232,7 +232,7 @@ export default {
       const weaponElement = parseInt(WeaponElement[selectedWeapon.element], 10);
       const weaponMultiplier = GetTotalMultiplierForTrait(selectedWeapon, playerElement);
       const totalPower = characterPower * weaponMultiplier + selectedWeapon.bonusPower;
-      const totalMultiplier = 1 + 0.075 * ((weaponElement === playerElement ? 1 : 0) + this.getElementAdvantage(playerElement, enemyElement));
+      const totalMultiplier = 1 + 0.075 * ((weaponElement === playerElement ? 1 : 0) + (0.075*this.getElementAdvantage(playerElement, enemyElement)));
       const playerMin = totalPower * totalMultiplier * 0.9;
       const playerMax = totalPower * totalMultiplier * 1.1;
       const playerRange = playerMax - playerMin;


### PR DESCRIPTION
getElementAdvantage(playerElement, enemyElement) returns 1, -1 or 0, and the percentage change due to this advantage is rather 7.5%, so by multiplying the return value of the function by 0.075, we solve the problem

### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

(insert description here)