### PR TITLE
Add durability to weapons

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -43,6 +43,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
         characterLimit = 4;
         staminaCostFight = 40;
+        durabilityCostFight = 1;
         mintCharacterFee = ABDKMath64x64.divu(10, 1);//10 usd;
         fightRewardBaseline = ABDKMath64x64.divu(1, 100);//0.01 usd;
         fightRewardGasOffset = ABDKMath64x64.divu(8, 10);//0.8 usd;
@@ -120,6 +121,8 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
     mapping(address => uint256) private _rewardsClaimTaxTimerStart;
 
+    uint8 durabilityCostFight;
+
     IStakeFromGame public stakeFromGameImpl;
 
     event FightOutcome(address indexed owner, uint256 indexed character, uint256 weapon, uint32 target, uint24 playerRoll, uint24 enemyRoll, uint16 xpGain, uint256 skillGain);
@@ -192,6 +195,8 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
             oncePerBlock(msg.sender)
             isCharacterOwner(char)
             isWeaponOwner(wep) {
+        require(weapons.getDurabilityPoints(wep) >= durabilityCostFight, "Not enough durability!");
+
         (uint8 charTrait, uint24 basePowerLevel, uint64 timestamp) =
             unpackFightData(characters.getFightDataAndDrainStamina(char, staminaCostFight));
 
@@ -199,6 +204,8 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
             int128 weaponMultFight,
             uint24 weaponBonusPower,
             uint8 weaponTrait) = weapons.getFightData(wep, charTrait);
+
+        weapons.drainDurability(wep, durabilityCostFight);
 
         _verifyFight(
             basePowerLevel,
@@ -566,6 +573,10 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
     function setStaminaCostFight(uint8 points) public restricted {
         staminaCostFight = points;
+    }
+
+    function setDurabilityCostFight(uint8 points) public restricted {
+        durabilityCostFight = points;
     }
 
     function setFightXpGain(uint256 average) public restricted {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -132,6 +132,7 @@ export default {
       'pollAccountsAndNetwork',
       'fetchWeaponTransferCooldownForOwnWeapons',
       'fetchCharacterTransferCooldownForOwnCharacters',
+      'setupWeaponDurabilities',
       'fetchStakeDetails',
       'fetchWaxBridgeDetails',
       'fetchRewardsClaimTax',
@@ -378,6 +379,7 @@ export default {
       await Promise.all([
         this.fetchCharacterTransferCooldownForOwnCharacters(),
         this.fetchWeaponTransferCooldownForOwnWeapons(),
+        this.setupWeaponDurabilities(),
         this.fetchWaxBridgeDetails(),
         this.fetchRewardsClaimTax(),
       ]);

--- a/frontend/src/components/WeaponIcon.vue
+++ b/frontend/src/components/WeaponIcon.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="weapon-icon"
+    v-bind:class="[getWeaponDurability(weapon.id) === 0 ? 'no-durability' : '']"
     v-tooltip="{ content: tooltipHtml , trigger: (isMobile() ? 'click' : 'hover') }"
     @mouseover="hover = !isMobile() || true"
     @mouseleave="hover = !isMobile()"
@@ -537,6 +538,10 @@ export default {
 
 .glow-4 {
   animation: glow-4 2000ms ease-out infinite alternate;
+}
+
+.no-durability {
+  opacity: 0.6;
 }
 
 @keyframes glow-1 {

--- a/frontend/src/components/WeaponIcon.vue
+++ b/frontend/src/components/WeaponIcon.vue
@@ -22,6 +22,13 @@
         {{ getWeaponNameFromSeed(weapon.id, weapon.stars) }}
       </div>
 
+      <div>
+        <div class="small-durability-bar"
+        :style="`--durabilityReady: ${(getWeaponDurability(weapon.id)/maxDurability)*100}%;`"
+        v-tooltip.bottom="`Durability: ${getWeaponDurability(weapon.id)}/${maxDurability}<br>
+          Repairs 1 point every 48 minutes, durability will be full at: ${timeUntilWeaponHasMaxDurability(weapon.id)}`"></div>
+      </div>
+
     </div>
 
     <div class="id">ID {{ weapon.id }}</div>
@@ -57,7 +64,7 @@ import { Stat1PercentForChar,
   Stat3PercentForChar
 } from '../interfaces';
 
-import { mapGetters } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
 const bladeCount = 24;
 const crossGuardCount = 24;
@@ -83,9 +90,12 @@ export default {
   props: ['weapon'],
 
   computed: {
+    ...mapState(['maxDurability']),
     ...mapGetters([
       'currentCharacter',
       'transferCooldownOfWeaponId',
+      'getWeaponDurability',
+      'timeUntilWeaponHasMaxDurability'
     ]),
     tooltipHtml() {
       if(!this.weapon) return '';
@@ -429,6 +439,17 @@ export default {
 </script>
 
 <style scoped>
+.small-durability-bar {
+  position: relative;
+  top: -5px;
+  height: 10px;
+  width: 80%;
+  margin: 0 auto;
+  border-radius: 2px;
+  border: 0.5px solid rgb(216, 215, 215);
+  background : linear-gradient(to right, rgb(236, 75, 75) var(--durabilityReady), rgba(255, 255, 255, 0.1) 0);
+}
+
 .weapon-icon {
   height: 100%;
   width: 100%;
@@ -491,7 +512,7 @@ export default {
 
 .name {
   position: absolute;
-  bottom: 5px;
+  bottom: 10px;
   left: 12%;
   right: 12%;
   font-size: 0.9em;

--- a/frontend/src/components/WeaponIcon.vue
+++ b/frontend/src/components/WeaponIcon.vue
@@ -512,7 +512,7 @@ export default {
 
 .name {
   position: absolute;
-  bottom: 10px;
+  bottom: 15px;
   left: 12%;
   right: 12%;
   font-size: 0.9em;

--- a/frontend/src/components/smart/WeaponGrid.vue
+++ b/frontend/src/components/smart/WeaponGrid.vue
@@ -42,7 +42,7 @@
         :class="{ selected: highlight !== null && weapon.id === highlight }"
         v-for="weapon in nonIgnoredWeapons"
         :key="weapon.id"
-        @click="onWeaponClick(weapon.id)"
+        @click="getWeaponDurability(weapon.id) > 0 && onWeaponClick(weapon.id)"
         @contextmenu="canFavorite && toggleFavorite($event, weapon.id)"
       >
         <b-icon v-if="isFavorite(weapon.id) === true" class="favorite-star" icon="star-fill" variant="warning" />
@@ -159,7 +159,7 @@ export default Vue.extend({
 
   computed: {
     ...(mapState(['ownedWeaponIds']) as Accessors<StoreMappedState>),
-    ...(mapGetters(['weaponsWithIds']) as Accessors<StoreMappedGetters>),
+    ...(mapGetters(['weaponsWithIds','getWeaponDurability',]) as Accessors<StoreMappedGetters>),
 
     weaponIdsToDisplay(): string[] {
       if (this.showGivenWeaponIds) {

--- a/frontend/src/interfaces/State.ts
+++ b/frontend/src/interfaces/State.ts
@@ -76,6 +76,8 @@ export interface IState {
 
   currentWeaponId: number | null;
   weapons: Record<number, IWeapon>;
+  weaponDurabilities: Record<number, number>;
+  maxDurability: number;
   targetsByCharacterIdAndWeaponId: Record<number, Record<number, ITarget>>;
 
   characterTransferCooldowns: Record<number, ITransferCooldown | undefined>;

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -303,7 +303,7 @@ export function createStore(web3: Web3) {
       timeUntilWeaponHasMaxDurability(state, getters) {
         return (id: number) => {
           const currentDurability = getters.getWeaponDurability(id);
-          if (!currentDurability) {
+          if (currentDurability === null || currentDurability === undefined) {
             return '';
           }
           const date = new Date();

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -108,7 +108,8 @@ export function createStore(web3: Web3) {
       characterStaminas: {},
       weapons: {},
       currentWeaponId: null,
-      isInCombat: false,
+      weaponDurabilities: {},
+      maxDurability: 0,      isInCombat: false,
       isCharacterViewExpanded: localStorage.getItem('isCharacterViewExpanded') ? localStorage.getItem('isCharacterViewExpanded') === 'true' : true,
 
       targetsByCharacterIdAndWeaponId: {},
@@ -191,6 +192,12 @@ export function createStore(web3: Web3) {
       getCharacterUnclaimedXp(state: IState) {
         return (characterId: number) => {
           return state.xpRewards[characterId];
+        };
+      },
+
+      getWeaponDurability(state: IState) {
+        return (weaponId: number) => {
+          return state.weaponDurabilities[weaponId];
         };
       },
 
@@ -280,6 +287,29 @@ export function createStore(web3: Web3) {
 
           if (state.maxStamina !== currentStamina) {
             date.setTime(date.getTime() + ((state.maxStamina - currentStamina) * (5 * 60000)));
+          }
+
+          return(`${
+            (date.getMonth()+1).toString().padStart(2, '0')}/${
+            date.getDate().toString().padStart(2, '0')}/${
+            date.getFullYear().toString().padStart(4, '0')} ${
+            date.getHours().toString().padStart(2, '0')}:${
+            date.getMinutes().toString().padStart(2, '0')}:${
+            date.getSeconds().toString().padStart(2, '0')}`
+          );
+        };
+      },
+
+      timeUntilWeaponHasMaxDurability(state, getters) {
+        return (id: number) => {
+          const currentDurability = getters.getWeaponDurability(id);
+          if (!currentDurability) {
+            return '';
+          }
+          const date = new Date();
+
+          if (state.maxDurability !== currentDurability) {
+            date.setTime(date.getTime() + ((state.maxDurability - currentDurability) * (48 * 60000)));
           }
 
           return(`${
@@ -395,7 +425,7 @@ export function createStore(web3: Web3) {
       },
 
       updateUserDetails(state: IState, payload) {
-        const keysToAllow = ['ownedCharacterIds', 'ownedWeaponIds', 'maxStamina'];
+        const keysToAllow = ['ownedCharacterIds', 'ownedWeaponIds', 'maxStamina', 'maxDurability'];
         for (const key of keysToAllow) {
           if (Object.hasOwnProperty.call(payload, key)) {
             Vue.set(state, key, payload[key]);
@@ -466,6 +496,9 @@ export function createStore(web3: Web3) {
         state.currentWeaponId = weaponId;
       },
 
+      updateWeaponDurability(state: IState, { weaponId, durability }) {
+        Vue.set(state.weaponDurabilities, weaponId, durability);
+      },
       updateCharacterStamina(state: IState, { characterId, stamina }) {
         Vue.set(state.characterStaminas, characterId, stamina);
       },
@@ -515,6 +548,7 @@ export function createStore(web3: Web3) {
         await dispatch('pollAccountsAndNetwork');
 
         await dispatch('setupCharacterStaminas');
+        await dispatch('setupWeaponDurabilities');
       },
 
       async pollAccountsAndNetwork({ state, dispatch, commit }) {
@@ -706,16 +740,19 @@ export function createStore(web3: Web3) {
           ownedCharacterIds,
           ownedWeaponIds,
           maxStamina,
+          maxDurability,
         ] = await Promise.all([
           state.contracts().CryptoBlades!.methods.getMyCharacters().call(defaultCallOptions(state)),
           state.contracts().CryptoBlades!.methods.getMyWeapons().call(defaultCallOptions(state)),
           state.contracts().Characters!.methods.maxStamina().call(defaultCallOptions(state)),
+          state.contracts().Weapons!.methods.maxDurability().call(defaultCallOptions(state)),
         ]);
 
         commit('updateUserDetails', {
           ownedCharacterIds: Array.from(ownedCharacterIds),
           ownedWeaponIds: Array.from(ownedWeaponIds),
-          maxStamina: parseInt(maxStamina, 10)
+          maxStamina: parseInt(maxStamina, 10),
+          maxDurability: parseInt(maxDurability, 10),
         });
 
         await Promise.all([
@@ -900,6 +937,31 @@ export function createStore(web3: Web3) {
         }
       },
 
+      async setupWeaponDurabilities({ state, dispatch }) {
+        const [
+          ownedWeaponIds
+        ] = await Promise.all([
+          state.contracts().CryptoBlades!.methods.getMyWeapons().call(defaultCallOptions(state))
+        ]);
+
+        for (const weapId of ownedWeaponIds) {
+          dispatch('fetchWeaponDurability', weapId);
+        }
+      },
+
+      async fetchWeaponDurability({ state, commit }, weaponId: number) {
+        if(featureFlagStakeOnly) return;
+
+        const durabilityString = await state.contracts().Weapons!.methods
+          .getDurabilityPoints('' + weaponId)
+          .call(defaultCallOptions(state));
+
+        const durability = parseInt(durabilityString, 10);
+        if (state.weaponDurabilities[weaponId] !== durability) {
+          commit('updateWeaponDurability', { weaponId, durability });
+        }
+      },
+
       async setupCharacterStaminas({ state, dispatch }) {
         const [
           ownedCharacterIds
@@ -966,7 +1028,8 @@ export function createStore(web3: Web3) {
 
         await Promise.all([
           dispatch('fetchFightRewardSkill'),
-          dispatch('fetchFightRewardXp')
+          dispatch('fetchFightRewardXp'),
+          dispatch('setupWeaponDurabilities')
         ]);
       },
 
@@ -1037,6 +1100,8 @@ export function createStore(web3: Web3) {
           xpGain,
           skillGain
         } = res.events.FightOutcome.returnValues;
+
+        await dispatch('fetchWeaponDurability', weaponId);
 
         return [parseInt(playerRoll, 10) >= parseInt(enemyRoll, 10),
           playerRoll,

--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -17,6 +17,8 @@
 
           <div class="message-box" v-if="currentCharacter && currentCharacterStamina < 40">You need 40 stamina to do battle.</div>
 
+          <div class="message-box" v-if="selectedWeaponId && !weaponHasDurabilit(selectedWeaponId)">This weapon does not have enoguh durability.</div>
+
           <div class="message-box" v-if="timeMinutes === 59 && timeSeconds >= 30">You cannot do battle during the last 30 seconds of the hour. Stand fast!</div>
         </div>
       </div>
@@ -61,7 +63,8 @@
                   <div class="combat-hints">
                     <span class="fire-icon" /> » <span class="earth-icon" /> » <span class="lightning-icon" /> » <span class="water-icon" /> »
                     <span class="fire-icon" />
-
+           <!-- && weaponHasDurabilit(selectedWeaponId) needs to be added below to block fights, but breaks the selected weapon icon if it returns false
+                meaning if weapon has no durability left -->
                     <Hint
                       text="The elements affect power:<br>
                       <br>Character vs Enemy: bonus or penalty as shown above
@@ -168,6 +171,7 @@ export default {
       'ownWeapons',
       'currentCharacter',
       'currentCharacterStamina',
+      'getWeaponDurability',
       'fightGasOffset',
       'fightBaseline'
     ]),
@@ -208,6 +212,9 @@ export default {
     ...mapActions(['fetchTargets', 'doEncounter', 'fetchFightRewardSkill', 'fetchFightRewardXp', 'getXPRewardsIfWin']),
     ...mapMutations(['setIsInCombat']),
     getEnemyArt,
+    weaponHasDurabilit(id) {
+      return this.getWeaponDurability(id) > 0;
+    },
     getCharacterTrait(trait) {
       return CharacterTrait[trait];
     },

--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -17,7 +17,7 @@
 
           <div class="message-box" v-if="currentCharacter && currentCharacterStamina < 40">You need 40 stamina to do battle.</div>
 
-          <div class="message-box" v-if="selectedWeaponId && !weaponHasDurabilit(selectedWeaponId)">This weapon does not have enoguh durability.</div>
+          <div class="message-box" v-if="selectedWeaponId && !weaponHasDurabilit(selectedWeaponId)">This weapon does not have enough durability.</div>
 
           <div class="message-box" v-if="timeMinutes === 59 && timeSeconds >= 30">You cannot do battle during the last 30 seconds of the hour. Stand fast!</div>
         </div>


### PR DESCRIPTION
This changes adds durability to weapons, similar to stamina for characters.

Importantly, durability is intended to limit a weapon's fight use to all 4 characters.  While the same maximum (200) could be used, the minimum needed is 1 durability per fight which maps to 20 durability.  A higher number can be used but it really should be a multiple of 20 (4 characters with 5 fights each per 16 hours).

I opted to use a mapping rather than adding a field to Weapon to align with the implementation for the transfer cooldown and to avoid potential issues with expanding Weapon.

Lastly, the need to apply a drain to two NFTs during a single operation (stamina for character and durability for weapon) must be done carefully to avoid draining one of them and failing a require when draining the other.