### PR TITLE
fix(calculator): help tooltip moved outside of button so a disabled button can't stop you from looking at help

### DIFF
--- a/frontend/src/components/smart/EarningsCalculator.vue
+++ b/frontend/src/components/smart/EarningsCalculator.vue
@@ -71,10 +71,10 @@
                   <b-button class="btn btn-primary" @click="calculateEarnings"
                     v-bind:class="[!canCalculate() ? 'disabled disabled-button' : '']">
                       Calculate
-                      <b-icon-question-circle class="centered-icon" scale="0.8"
-                      v-tooltip.bottom="`Earnings on victory: ${this.formattedSkill(this.fightGasOffset)} gas offset +
-                      ${this.stringFormattedSkill(this.fightBaseline)} per square root of power/1000`"/>
                   </b-button>
+                  <b-icon-question-circle class="centered-icon" scale="1.5"
+                    v-tooltip.bottom="`Earnings on victory: ${this.stringFormattedSkill(this.fightGasOffset)} gas offset +
+                    ${this.stringFormattedSkill(this.fightBaseline)} per square root of power/1000`"/>
                 </div>
               </div>
 
@@ -504,5 +504,10 @@ export default Vue.extend({
 .btn-small {
   font-size: small;
   margin-top: 5px;
+}
+
+.centered-icon {
+  align-self: center;
+  margin-left: 5px;
 }
 </style>


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Moved the tooltip outside of the calculate button and fixed the decimal places amoutn of gas offset.