### PR TITLE
fix(math): ui passing wrong level to power calculator function

### DIFF
--- a/frontend/src/components/smart/EarningsCalculator.vue
+++ b/frontend/src/components/smart/EarningsCalculator.vue
@@ -275,7 +275,7 @@ export default Vue.extend({
 
     getRewardDiffBonus(level: number, targetLevel: number): string {
       return (this.getAverageRewardAtLevel(targetLevel) /
-        this.getAverageRewardAtLevel(level) * 100 - 100).toFixed(2);
+        this.getAverageRewardAtLevel(level + 1) * 100 - 100).toFixed(2);
     },
 
     formattedSkill(skill: number): number {


### PR DESCRIPTION
… in wrong milestone bonus percentage

### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Fixes wrong level being passed to character power function, resulting in wrong milestone bonus percentage.