### PR TITLE
fix(character): character name should cut off more gracefully

### DIFF
--- a/frontend/src/components/CharacterArt.vue
+++ b/frontend/src/components/CharacterArt.vue
@@ -526,6 +526,8 @@ export default {
   font-weight: 900;
   overflow: hidden;
   max-height: 24px;
+  max-width: 170px;
+  white-space: nowrap;
 }
 
 .xp {


### PR DESCRIPTION
### All Submissions

![image](https://user-images.githubusercontent.com/25894844/126433941-0a2df4e9-6c8d-4b37-93c6-2e20e417ec03.png)

### Notes

Could potentially update this so that the layout for the first name is centred instead of being off to the side.

### New Feature Submissions

The last name of the character no longer disappears and aesthetically looks a bit better.

### PR Description

Updated CSS so that the last name of the character no longer wraps and disappears.