### PR TITLE
feat(market): show character stamina on market

### DIFF
--- a/frontend/src/components/CharacterArt.vue
+++ b/frontend/src/components/CharacterArt.vue
@@ -12,7 +12,7 @@
 
     <div class="name-lvl-container">
       <div class="name black-outline" v-if="!portrait">{{ getCharacterName(character.id) }} </div>
-      <div>Lv.<span class="white">{{ character.level + 1 }}</span></div>
+      <div v-if="!portrait">Lv.<span class="white">{{ character.level + 1 }}</span></div>
     </div>
     <div class="score-id-container">
     <div class="black-outline" v-if="!portrait">ID <span class="white">{{ character.id }}</span></div>
@@ -21,6 +21,12 @@
       <b-icon-question-circle class="centered-icon" scale="0.8" v-tooltip.bottom="`Hero score is a measure of your hero's combat prowess so far.
         It goes up when you win and down when you lose.`"/>
     </div>
+    </div>
+
+    <div v-if="!portrait && isMarket" class="small-stamina-char"
+      :style="`--staminaReady: ${(timestampToStamina(character.staminaTimestamp)/maxStamina)*100}%;`"
+      v-tooltip.bottom="staminaToolTipHtml(timeUntilCharacterHasMaxStamina(character.id))">
+      <div class="stamina-text black-outline">STA {{ timestampToStamina(character.staminaTimestamp) }} / 200</div>
     </div>
 
     <div class="xp" v-if="!portrait">
@@ -44,7 +50,7 @@ import torsos from '../assets/characterWardrobe_torso.json';
 import legs from '../assets/characterWardrobe_legs.json';
 import boots from '../assets/characterWardrobe_boots.json';
 import { CharacterTrait, RequiredXp } from '../interfaces';
-import { mapGetters} from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
 const headCount = 13;
 const armsCount = 45;
@@ -62,7 +68,7 @@ function transformModel(model) {
 }
 
 export default {
-  props: ['character', 'portrait'],
+  props: ['character', 'portrait', 'isMarket'],
   watch: {
     character() {
       this.clearScene();
@@ -90,7 +96,13 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['getCharacterName', 'transferCooldownOfCharacterId', 'getCharacterUnclaimedXp']),
+    ...mapState(['maxStamina']),
+    ...mapGetters([
+      'getCharacterName',
+      'transferCooldownOfCharacterId',
+      'getCharacterUnclaimedXp',
+      'timeUntilCharacterHasMaxStamina'
+    ]),
   },
 
   methods: {
@@ -108,6 +120,15 @@ export default {
       }
 
       return '';
+    },
+
+    staminaToolTipHtml(time) {
+      return 'Regenerates 1 point every 5 minutes, stamina bar will be full at: ' + time;
+    },
+
+    timestampToStamina(timestamp) {
+      if(timestamp > Math.floor(Date.now()/1000)) return 0;
+      return +Math.min((Math.floor(Date.now()/1000) - timestamp) / 300, 200).toFixed(0);
     },
 
     getCharacterArt,
@@ -504,10 +525,11 @@ export default {
 }
 
 .trait {
-  top: -27px;
+  top: -30px;
   justify-self: center;
   margin: 0 auto;
   position: relative;
+  display: flex;
 }
 
 .id {
@@ -561,10 +583,32 @@ export default {
 .name-lvl-container, .score-id-container {
   display :flex;
   justify-content: space-around;
+  position: relative;
 }
 
 .white {
   color : rgb(204, 204, 204)
 }
 
+.small-stamina-char {
+  position: relative;
+  margin-top: -10px;
+  top: 7px;
+  align-self: center;
+  height :14px;
+  width: 180px;
+  border-radius: 2px;
+  border: 0.5px solid rgb(216, 215, 215);
+  background : linear-gradient(to right, rgb(236, 75, 75) var(--staminaReady), rgba(255, 255, 255, 0.1) 0);
+}
+
+.stamina-text {
+  position: relative;
+  top: -3px;
+  font-size: 75%;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #fff;
+}
 </style>

--- a/frontend/src/components/smart/CharacterDisplay.vue
+++ b/frontend/src/components/smart/CharacterDisplay.vue
@@ -159,37 +159,6 @@ export default Vue.extend({
       return 'Regenerates 1 point every 5 minutes, stamina bar will be full at: ' + time;
     },
 
-    getNextMilestoneBonus(level: number, fightGasOffset: number, fightRewardBaseling: number): string {
-      const nextMilestoneLevel = this.getNextMilestoneLevel(level);
-      return this.getRewardDiffBonus(level, nextMilestoneLevel, fightGasOffset, fightRewardBaseling);
-    },
-
-    getNextMilestoneLevel(level: number): number {
-      return (Math.floor(level / 10) + 1) * 10 + 1;
-    },
-
-    getMilestonesTooltip(level: number, fightGasOffset: number, fightRewardBaseling: number): string {
-      const nextMilestoneLevel1 = this.getNextMilestoneLevel(level);
-      const nextMilestoneLevel2 = this.getNextMilestoneLevel(nextMilestoneLevel1);
-      const nextMilestoneLevel3 = this.getNextMilestoneLevel(nextMilestoneLevel2);
-      const nextMilestoneLevel4 = this.getNextMilestoneLevel(nextMilestoneLevel3);
-      const nextMilestoneLevel5 = this.getNextMilestoneLevel(nextMilestoneLevel4);
-      return `LVL ${nextMilestoneLevel1} = +${this.getRewardDiffBonus(level, nextMilestoneLevel1, fightGasOffset, fightRewardBaseling)}%<br/>
-      LVL ${nextMilestoneLevel2} = +${this.getRewardDiffBonus(level, nextMilestoneLevel2, fightGasOffset, fightRewardBaseling)}%<br/>
-      LVL ${nextMilestoneLevel3} = +${this.getRewardDiffBonus(level, nextMilestoneLevel3, fightGasOffset, fightRewardBaseling)}%<br/>
-      LVL ${nextMilestoneLevel4} = +${this.getRewardDiffBonus(level, nextMilestoneLevel4, fightGasOffset, fightRewardBaseling)}%<br/>
-      LVL ${nextMilestoneLevel5} = +${this.getRewardDiffBonus(level, nextMilestoneLevel5, fightGasOffset, fightRewardBaseling)}%`;
-    },
-
-    getAverageRewardAtLevel(level: number, fightGasOffset: number, fightRewardBaseling: number): number {
-      return this.formattedSkill(fightGasOffset) + (this.formattedSkill(fightRewardBaseling) * (CharacterPower(level)/1000));
-    },
-
-    getRewardDiffBonus(level: number, targetLevel: number, fightGasOffset: number, fightRewardBaseling: number): string {
-      return (this.getAverageRewardAtLevel(targetLevel, fightGasOffset, fightRewardBaseling) /
-        this.getAverageRewardAtLevel(level, fightGasOffset, fightRewardBaseling) * 100 - 100).toFixed(2);
-    },
-
     formattedSkill(skill: number): number {
       const skillBalance = Web3.utils.fromWei(skill.toString(), 'ether');
       return new BN(skillBalance).toNumber();

--- a/frontend/src/components/smart/CharacterList.vue
+++ b/frontend/src/components/smart/CharacterList.vue
@@ -43,7 +43,7 @@
           <slot name="above" :character="c"></slot>
         </div>
         <div class="art">
-          <CharacterArt :character="c" />
+          <CharacterArt :character="c" :isMarket="isMarket"/>
         </div>
       </li>
     </ul>
@@ -143,20 +143,6 @@ export default {
     ...mapActions(['fetchCharacters']),
 
     getCharacterArt,
-
-    getStaminaPoints(timestamp_str) {
-      // super temporary function, just to make it work for now. sorry
-      const timestamp = parseInt(timestamp_str, 10);
-      const now = Date.now();
-      if(timestamp  > now)
-        return 0;
-
-      let points = (now - timestamp) / 300;
-      if(points > 200) {
-        points = 200;
-      }
-      return points;
-    },
 
     saveFilters() {
       sessionStorage.setItem('character-levelfilter', this.levelFilter);


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?
Market | Plaza:
![image](https://user-images.githubusercontent.com/9114200/126453070-2691f354-9cb2-4d3f-bc63-9694d3acc7c3.png) ![image](https://user-images.githubusercontent.com/9114200/126453131-3d0c357a-33ff-4a7d-b6b8-c33de774ae3c.png)

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
https://github.com/CryptoBlades/cryptoblades/issues/316
### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Stamina shown only in the market character card, as showing by default would duplicate the information we have in the character picker.

Implementation + cleanup of some unused code. 

Stamina calculated from staminaTimestamp which is available in character object we're already using.
If that's not ideal I can rework with fetching stamina for each character.
