### PR TITLE
feat(calculator): add market ability to load existing char/weapon pair

### DIFF
--- a/frontend/src/components/smart/EarningsCalculator.vue
+++ b/frontend/src/components/smart/EarningsCalculator.vue
@@ -12,7 +12,7 @@
           <span class="milestone-lvl-text">LVL {{getNextMilestoneLevel(currentCharacter.level)}}</span><br>
           <b-button class="btn btn-primary btn-small" @click="onShowEarningsCalculator">
             <b-icon-calculator-fill class="milestone-hint" scale="1"
-              v-tooltip.bottom="`Eranings Calculator`"/>
+              v-tooltip.bottom="`Earnings Calculator`"/>
               Earnings Calculator
           </b-button>
 

--- a/frontend/src/components/smart/EarningsCalculator.vue
+++ b/frontend/src/components/smart/EarningsCalculator.vue
@@ -154,6 +154,7 @@ export default Vue.extend({
   computed: {
     ...mapGetters([
       'currentCharacter',
+      'currentWeapon',
       'fightGasOffset',
       'fightBaseline'
     ]),
@@ -184,6 +185,33 @@ export default Vue.extend({
 
   methods: {
     async onShowEarningsCalculator() {
+      if(this.currentCharacter !== null) {
+        this.characterElementValue = CharacterTrait[this.currentCharacter.trait];
+        this.levelSliderValue = this.currentCharacter.level + 1;
+      }
+
+      if(this.currentWeapon !== null) {
+        console.log(this.currentWeapon.stars);
+        console.log(this.currentWeapon.element);
+        console.log(this.currentWeapon.stat1);
+        console.log(this.currentWeapon.stat2);
+        console.log(this.currentWeapon.stat3);
+        console.log(this.currentWeapon.stat1Value);
+        console.log(this.currentWeapon.stat2Value);
+        console.log(this.currentWeapon.stat3Value);
+        console.log(this.currentWeapon.bonusPower);
+
+        this.starsValue = this.currentWeapon.stars + 1;
+        this.wepElementValue = this.currentWeapon.element;
+        this.wepFirstStatSliderValue = this.currentWeapon.stat1Value;
+        this.wepSecondStatSliderValue = this.starsValue > 3 && this.currentWeapon.stat2Value;
+        this.wepThirdStatSliderValue = this.starsValue > 4 && this.currentWeapon.stat3Value;
+        this.wepFirstStatElementValue = this.currentWeapon.stat1;
+        this.wepSecondStatElementValue = this.starsValue > 3 && this.currentWeapon.stat2;
+        this.wepThirdStatElementValue = this.starsValue > 4 && this.currentWeapon.stat3;
+        this.wepBonusPowerSliderValue = this.currentWeapon.bonusPower;
+      }
+
       await this.fetchPrices();
       (this.$refs['earnings-calc-modal'] as any).show();
     },

--- a/frontend/src/components/smart/EarningsCalculator.vue
+++ b/frontend/src/components/smart/EarningsCalculator.vue
@@ -12,7 +12,7 @@
           <span class="milestone-lvl-text">LVL {{getNextMilestoneLevel(currentCharacter.level)}}</span><br>
           <b-button class="btn btn-primary btn-small" @click="onShowEarningsCalculator">
             <b-icon-calculator-fill class="milestone-hint" scale="1"
-              v-tooltip.bottom="`Eranings Calculator`" v-on:click="onShowEarningsCalculator"/>
+              v-tooltip.bottom="`Eranings Calculator`"/>
               Earnings Calculator
           </b-button>
 
@@ -68,6 +68,9 @@
                   </div>
                 </div>
                 <div class="button-div">
+                  <b-button class="btn btn-primary" @click="onReset">
+                      Reset
+                  </b-button>
                   <b-button class="btn btn-primary" @click="calculateEarnings"
                     v-bind:class="[!canCalculate() ? 'disabled disabled-button' : '']">
                       Calculate
@@ -82,7 +85,7 @@
                 <span class="calculator-subheader">Weapon</span>
                 <img src="../../assets/placeholder/sword-placeholder-0.png" class="wep-placeholder">
                 <span>Stars</span>
-                <b-form-rating class="stars-picker" variant="warning" v-model="starsValue" size="sm"></b-form-rating>
+                <b-form-rating @change="refreshWeaponStats" class="stars-picker" variant="warning" v-model="starsValue" size="sm"></b-form-rating>
                 <span>Element</span>
                 <select class="form-control wep-trait-form" v-model="wepElementValue">
                   <option v-for="x in ['Earth', 'Fire', 'Lightning', 'Water']" :value="x" :key="x">{{ x }}</option>
@@ -191,16 +194,6 @@ export default Vue.extend({
       }
 
       if(this.currentWeapon !== null) {
-        console.log(this.currentWeapon.stars);
-        console.log(this.currentWeapon.element);
-        console.log(this.currentWeapon.stat1);
-        console.log(this.currentWeapon.stat2);
-        console.log(this.currentWeapon.stat3);
-        console.log(this.currentWeapon.stat1Value);
-        console.log(this.currentWeapon.stat2Value);
-        console.log(this.currentWeapon.stat3Value);
-        console.log(this.currentWeapon.bonusPower);
-
         this.starsValue = this.currentWeapon.stars + 1;
         this.wepElementValue = this.currentWeapon.element;
         this.wepFirstStatSliderValue = this.currentWeapon.stat1Value;
@@ -214,6 +207,21 @@ export default Vue.extend({
 
       await this.fetchPrices();
       (this.$refs['earnings-calc-modal'] as any).show();
+    },
+
+    onReset() {
+      this.characterElementValue = '';
+      this.levelSliderValue =  1;
+      this.starsValue =  1;
+      this.wepElementValue =  '';
+      this.wepFirstStatElementValue =  '';
+      this.wepSecondStatElementValue =  '';
+      this.wepThirdStatElementValue =  '';
+      this.wepFirstStatSliderValue =  4;
+      this.wepSecondStatSliderValue =  4;
+      this.wepThirdStatSliderValue =  4;
+      this.wepBonusPowerSliderValue =  0;
+      this.calculationResults = [] as number[][];
     },
 
     getMinRoll(stars: number): number {
@@ -321,15 +329,13 @@ export default Vue.extend({
       if(this.calculationResults[i][0] < 0) return 'negative-value';
       return 'positive-value';
     },
-  },
 
-  watch: {
-    starsValue(value: number) {
+    refreshWeaponStats(value: number) {
       this.wepFirstStatSliderValue = this.getMinRoll(value);
       this.wepSecondStatSliderValue = this.getMinRoll(value);
       this.wepThirdStatSliderValue = this.getMinRoll(value);
-    },
-  }
+    }
+  },
 });
 </script>
 <style scoped>
@@ -515,6 +521,10 @@ export default Vue.extend({
   margin-top: 5px;
   display: flex;
   justify-content: center;
+}
+
+.button-div > * {
+  margin: 5px;
 }
 
 .disabled-button {

--- a/frontend/src/components/smart/WeaponGrid.vue
+++ b/frontend/src/components/smart/WeaponGrid.vue
@@ -42,7 +42,7 @@
         :class="{ selected: highlight !== null && weapon.id === highlight }"
         v-for="weapon in nonIgnoredWeapons"
         :key="weapon.id"
-        @click="$emit('choose-weapon', weapon.id)"
+        @click="onWeaponClick(weapon.id)"
         @contextmenu="canFavorite && toggleFavorite($event, weapon.id)"
       >
         <b-icon v-if="isFavorite(weapon.id) === true" class="favorite-star" icon="star-fill" variant="warning" />
@@ -60,7 +60,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Accessors, PropType } from 'vue/types/options';
-import { mapActions, mapGetters, mapState } from 'vuex';
+import { mapActions, mapGetters, mapMutations, mapState } from 'vuex';
 import { IState, IWeapon } from '../../interfaces';
 import WeaponIcon from '../WeaponIcon.vue';
 
@@ -219,6 +219,7 @@ export default Vue.extend({
 
   methods: {
     ...(mapActions(['fetchWeapons']) as StoreMappedActions),
+    ...(mapMutations(['setCurrentWeapon'])),
 
     saveFilters() {
       sessionStorage.setItem('weapon-starfilter', this.starFilter);
@@ -270,6 +271,11 @@ export default Vue.extend({
 
       this.$emit('weapon-filters-changed');
     },
+
+    onWeaponClick(id: number) {
+      this.setCurrentWeapon(id);
+      this.$emit('choose-weapon', id);
+    }
   },
 
   mounted() {

--- a/frontend/src/interfaces/State.ts
+++ b/frontend/src/interfaces/State.ts
@@ -74,6 +74,7 @@ export interface IState {
   characters: Record<number, ICharacter>;
   characterStaminas: Record<number, number>;
 
+  currentWeaponId: number | null;
   weapons: Record<number, IWeapon>;
   targetsByCharacterIdAndWeaponId: Record<number, Record<number, ITarget>>;
 

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -107,6 +107,7 @@ export function createStore(web3: Web3) {
       characters: {},
       characterStaminas: {},
       weapons: {},
+      currentWeaponId: null,
       isInCombat: false,
       isCharacterViewExpanded: localStorage.getItem('isCharacterViewExpanded') ? localStorage.getItem('isCharacterViewExpanded') === 'true' : true,
 
@@ -219,6 +220,12 @@ export function createStore(web3: Web3) {
           if (weapons.some((w) => w === null)) return [];
           return weapons;
         };
+      },
+
+      currentWeapon(state) {
+        if (state.currentWeaponId === null) return null;
+
+        return state.weapons[state.currentWeaponId];
       },
 
       transferCooldownOfCharacterId(state) {
@@ -453,6 +460,10 @@ export function createStore(web3: Web3) {
         { weaponId, weaponTransferCooldown }: { weaponId: number, weaponTransferCooldown: ITransferCooldown }
       ) {
         Vue.set(state.weaponTransferCooldowns, weaponId, weaponTransferCooldown);
+      },
+
+      setCurrentWeapon(state: IState, weaponId: number) {
+        state.currentWeaponId = weaponId;
       },
 
       updateCharacterStamina(state: IState, { characterId, stamina }) {

--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -204,10 +204,6 @@ export default {
       this.waitingResults = fightResults === null && error === null;
       this.setIsInCombat(this.waitingResults);
     },
-
-    selectedWeaponId() {
-      localStorage.setItem('selected-weapon-id', this.selectedWeaponId);
-    },
   },
 
   methods: {

--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -204,6 +204,10 @@ export default {
       this.waitingResults = fightResults === null && error === null;
       this.setIsInCombat(this.waitingResults);
     },
+
+    selectedWeaponId() {
+      localStorage.setItem('selected-weapon-id', this.selectedWeaponId);
+    },
   },
 
   methods: {


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?
![image](https://user-images.githubusercontent.com/9114200/126466803-77cc6a8c-dda2-43d2-b66e-132c4918f81b.png)

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
https://github.com/CryptoBlades/cryptoblades/issues/357
### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Character / weapon stats in calculator are initally populated with currently selected character / weapon stats. There's a 'reset' button provided at the bottom to clear all values.