### PR TITLE
Add .vs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ report*.json
 .vscode/launch.json
 package-lock.json
 frontend/package-lock.json
+.vs


### PR DESCRIPTION
Prevents accidental check-in of Visual Studio piddles.