### PR TITLE
feat(market): move purchase button onto individual cards so it's easier to see

### DIFF
--- a/frontend/src/components/CharacterArt.vue
+++ b/frontend/src/components/CharacterArt.vue
@@ -4,7 +4,19 @@
       <span :class="trait.toLowerCase() + '-icon circle-element'"></span>
     </div>
 
-    <img v-if="showPlaceholder && !portrait" class="placeholder" :src="getCharacterArt(character)" />
+    <div class="placeholder d-flex align-items-start justify-content-center p-1"
+      >
+      <div class="w-100" :style="{
+        'background-image': 'url(' + getCharacterArt(character) + ')',
+      }"
+      :class="{
+        'h-100': !isMarket,
+        'h-75': isMarket
+      }">
+
+      </div>
+      <!--<small-button class="button" :text="`Purchase`" v-if="isMarket"/>-->
+    </div>
 
     <div class="loading-container" v-if="!allLoaded">
       <i class="fas fa-spinner fa-spin"></i>
@@ -51,6 +63,7 @@ import legs from '../assets/characterWardrobe_legs.json';
 import boots from '../assets/characterWardrobe_boots.json';
 import { CharacterTrait, RequiredXp } from '../interfaces';
 import { mapGetters, mapState } from 'vuex';
+//import SmallButton from './SmallButton.vue';
 
 const headCount = 13;
 const armsCount = 45;
@@ -69,6 +82,9 @@ function transformModel(model) {
 
 export default {
   props: ['character', 'portrait', 'isMarket'],
+  components: {
+    //SmallButton,
+  },
   watch: {
     character() {
       this.clearScene();
@@ -574,6 +590,12 @@ export default {
   padding-top: 0;
   -o-object-fit: contain;
   object-fit: contain;
+}
+
+.placeholder div{
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .circle-element {

--- a/frontend/src/components/SmallButton.vue
+++ b/frontend/src/components/SmallButton.vue
@@ -1,6 +1,6 @@
 <template>
   <button :disabled="disabled" class="button main-font dark-bg-text" @click="$emit('click')">
-    <h3>{{ text }}</h3>
+    {{ text }}
   </button>
 </template>
 
@@ -29,7 +29,4 @@ export default {
   opacity: 0.4;
 }
 
-h3 {
-  margin: auto;
-}
 </style>

--- a/frontend/src/components/smart/WeaponGrid.vue
+++ b/frontend/src/components/smart/WeaponGrid.vue
@@ -46,11 +46,11 @@
         @contextmenu="canFavorite && toggleFavorite($event, weapon.id)"
       >
         <b-icon v-if="isFavorite(weapon.id) === true" class="favorite-star" icon="star-fill" variant="warning" />
-        <div class="above-wrapper" v-if="$slots.above || $scopedSlots.above">
-          <slot name="above" :weapon="weapon"></slot>
-        </div>
         <div class="weapon-icon-wrapper">
           <weapon-icon class="weapon-icon" :weapon="weapon" />
+        </div>
+        <div class="above-wrapper" v-if="$slots.above || $scopedSlots.above">
+          <slot name="above" :weapon="weapon"></slot>
         </div>
       </li>
     </ul>
@@ -319,7 +319,7 @@ export default Vue.extend({
 }
 
 .above-wrapper {
-  padding: 0.5rem;
+  padding: 0.1rem;
 }
 
 .toggle-button {

--- a/frontend/src/views/Market.vue
+++ b/frontend/src/views/Market.vue
@@ -81,11 +81,20 @@
                 v-model="selectedNftId">
 
                 <template #above="{ character: { id } }">
-                  <div class="token-price">
+                  <div class="token-price d-flex flex-column align-items-center justify-content-center"
+                    style="margin-top: -50px;">
                     <span class="d-block text-center" v-if="nftPricesById[id]">
-                      {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
-                    </span>
+                       {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
+                     </span>
                     <span class="d-block text-center" v-else>Loading price...</span>
+                    <b-button
+                      @click="selectedNftId = id; canPurchase && purchaseNft();"
+                      variant="primary"
+                      v-bind:class="[!canPurchase ? 'disabled-button' : '']"
+                      class="gtag-link-others" tagname="confirm_purchase">
+                      Purchase <b-icon-question-circle v-if="!canPurchase"
+                      v-tooltip.bottom="'You already have max amount of characters (4).'"/>
+                    </b-button>
                   </div>
                 </template>
 
@@ -363,6 +372,7 @@ import BigNumber from 'bignumber.js';
 import { BModal } from 'bootstrap-vue';
 import { traitNameToNumber } from '@/contract-models';
 import { market_blockchain as useBlockchain } from './../feature-flags';
+
 type SellType = 'weapon' | 'character';
 type WeaponId = string;
 type CharacterId = string;

--- a/frontend/src/views/Market.vue
+++ b/frontend/src/views/Market.vue
@@ -24,17 +24,6 @@
                   @click="searchAllWeaponListings(currentPage - 1)"  class="gtag-link-others" tagname="browse_weapons">Browse Weapons</b-button>
               </div>
 
-              <div class="col">
-                <b-button
-                  variant="primary"
-                  v-if="buyableNftSelected"
-                  v-bind:class="[!canPurchase ? 'disabled-button' : '']"
-                  @click="canPurchase && purchaseNft()" class="gtag-link-others" tagname="confirm_purchase">
-                  Purchase <b-icon-question-circle v-if="!canPurchase"
-                  v-tooltip.bottom="'You already have max amount of characters (4).'"/>
-                </b-button>
-              </div>
-
               <div class="col"></div>
             </div>
 
@@ -62,10 +51,19 @@
                 v-model="selectedNftId">
 
                 <template #above="{ weapon: { id } }">
-                  <span class="d-block text-center" v-if="nftPricesById[id]">
-                    <strong>Price</strong>: {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
-                  </span>
-                  <span class="d-block text-center" v-else>Loading price...</span>
+                  <div class="d-flex flex-column align-items-center justify-content-center"
+                  style="margin-top: -10px;">
+                    <span class="d-block text-center" v-if="nftPricesById[id]">
+                      <strong>Price</strong>: {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
+                    </span>
+                    <span class="d-block text-center" v-else>Loading price...</span>
+                    <b-button
+                      @click="selectedNftId = id; purchaseNft();"
+                      variant="primary"
+                      class="gtag-link-others">
+                      Purchase
+                    </b-button>
+                  </div>
                 </template>
 
               </weapon-grid>
@@ -187,17 +185,6 @@
               <div class="col">
                 <b-button
                   variant="primary"
-                  v-if="buyableNftSelected"
-                  v-bind:class="[!canPurchase ? 'disabled-button' : '']"
-                  @click="canPurchase && purchaseNft()" class="gtag-link-others" tagname="confirm_purchase">
-                  Purchase <b-icon-question-circle v-if="!canPurchase"
-                  v-tooltip.bottom="'You already have max amount of characters (4).'"/>
-                </b-button>
-              </div>
-
-              <div class="col">
-                <b-button
-                  variant="primary"
                   v-if="ownListedNftSelected"
                   @click="updateNftListingPrice()"  class="gtag-link-others" tagname="change_price">Change Price</b-button>
               </div>
@@ -222,10 +209,20 @@
                 v-model="selectedNftId">
 
                 <template #above="{ weapon: { id } }">
-                  <span class="d-block text-center" v-if="nftPricesById[id]">
-                    <strong>Price</strong>: {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
-                  </span>
-                  <span class="d-block text-center" v-else>Loading price...</span>
+                  <div class="d-flex flex-column align-items-center justify-content-center"
+                  style="margin-top: -10px;">
+                    <span class="d-block text-center" v-if="nftPricesById[id]">
+                      <strong>Price</strong>: {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
+                    </span>
+                    <span class="d-block text-center" v-else>Loading price...</span>
+                    <b-button
+                        v-if="id !== null && !searchResultsOwned"
+                        @click="selectedNftId = id; purchaseNft();"
+                        variant="primary"
+                        class="gtag-link-others">
+                        Purchase
+                    </b-button>
+                  </div>
                 </template>
 
               </weapon-grid>

--- a/frontend/src/views/Market.vue
+++ b/frontend/src/views/Market.vue
@@ -51,8 +51,7 @@
                 v-model="selectedNftId">
 
                 <template #above="{ weapon: { id } }">
-                  <div class="d-flex flex-column align-items-center justify-content-center"
-                  style="margin-top: -10px;">
+                  <div class="d-flex flex-column align-items-center justify-content-center m-top-negative-5">
                     <span class="d-block text-center" v-if="nftPricesById[id]">
                       <strong>Price</strong>: {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
                     </span>
@@ -79,8 +78,7 @@
                 v-model="selectedNftId">
 
                 <template #above="{ character: { id } }">
-                  <div class="token-price d-flex flex-column align-items-center justify-content-center"
-                    style="margin-top: -50px;">
+                  <div class="token-price d-flex flex-column align-items-center justify-content-center m-top-negative-50">
                     <span class="d-block text-center" v-if="nftPricesById[id]">
                        {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
                      </span>
@@ -209,8 +207,7 @@
                 v-model="selectedNftId">
 
                 <template #above="{ weapon: { id } }">
-                  <div class="d-flex flex-column align-items-center justify-content-center"
-                  style="margin-top: -10px;">
+                  <div class="d-flex flex-column align-items-center justify-content-center m-top-negative-5">
                     <span class="d-block text-center" v-if="nftPricesById[id]">
                       <strong>Price</strong>: {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
                     </span>
@@ -236,11 +233,20 @@
                 v-model="selectedNftId">
 
                 <template #above="{ character: { id } }">
-                  <div class="token-price">
+                  <div class="token-price d-flex flex-column align-items-center justify-content-center m-top-negative-50">
                     <span class="d-block text-center" v-if="nftPricesById[id]">
                       {{ convertWeiToSkill(nftPricesById[id]) | maxDecimals(2) }} SKILL
                     </span>
                     <span class="d-block text-center" v-else>Loading price...</span>
+                    <b-button
+                      v-if="id !== null && !searchResultsOwned"
+                      @click="selectedNftId = id; canPurchase && purchaseNft();"
+                      variant="primary"
+                      v-bind:class="[!canPurchase ? 'disabled-button' : '']"
+                      class="gtag-link-others" tagname="confirm_purchase">
+                      Purchase <b-icon-question-circle v-if="!canPurchase"
+                      v-tooltip.bottom="'You already have max amount of characters (4).'"/>
+                    </b-button>
                   </div>
                 </template>
 
@@ -1070,6 +1076,14 @@ export default Vue.extend({
 
 .disabled-button {
   opacity: 0.65;
+}
+
+.m-top-negative-5{
+  margin-top: -5px;
+}
+
+.m-top-negative-50{
+  margin-top: -50px;
 }
 
 </style>


### PR DESCRIPTION
### Images
![image](https://user-images.githubusercontent.com/29177296/126585065-f4016641-cb3b-47e7-a6f0-d6fd7fcc5f9c.png)
![image](https://user-images.githubusercontent.com/29177296/126585191-be03bee4-7198-45bb-ae73-1152b7ed79e7.png)


### PR Description

* Change purchase workflow and put purchase button at the bottom of characters and weapons, so the user will purchase easier