### PR TITLE
fix(market): sell popup precision was off

### DIFF
--- a/frontend/src/views/Market.vue
+++ b/frontend/src/views/Market.vue
@@ -1042,7 +1042,7 @@ export default Vue.extend({
     },
 
     calculatedBuyerCost(listedPrice: number): string {
-      return (0.01 * listedPrice * (100 + parseFloat(this.activeListingMarketTax()))).toFixed(2);
+      return (0.01 * listedPrice * (100 + parseFloat(this.activeListingMarketTax()))).toFixed(8).replace(/(\.0+|0+)$/, '');
     },
 
     maxPrecisionSkill(listedPrice: string): string {


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?
* [ ] 
![image](https://user-images.githubusercontent.com/25177987/126860558-3672c4e6-0c25-4610-8474-d8da6d3cc68b.png)
![image](https://user-images.githubusercontent.com/25177987/126860562-ae4a9141-82d3-494a-b9d2-57108315d4a6.png)
![image](https://user-images.githubusercontent.com/25177987/126860567-730ed15f-ef37-4934-bf13-1efb38cb63ef.png)
![image](https://user-images.githubusercontent.com/25177987/126860576-2953ec8e-3bfe-4c84-9191-0886d49f7fd3.png)
![image](https://user-images.githubusercontent.com/25177987/126860580-23bd71ad-58b6-4a0e-b262-0a7c726b8cb5.png)
![image](https://user-images.githubusercontent.com/25177987/126860585-10bebf3c-8a20-48aa-af58-ca252f7a9962.png)


### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
* [x] #430 

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

We added support on market to properly display < 0.01 SKILL items so I figured we need to do it here as well.
javascript just doesn't like dividing by 100 or multiplying by 0.01 and ends up giving like 0.12100000000000001. The simplest solution I could come up with because I don't think this is worth adding some custom libraries or whatever was to just toFixed(8) and trim any trailing 0s. Went with 8 because that's what we show in the tool tip in market for the _exact_ value.

_Me cleaning my mess, no bounties on this one_

