### PR TITLE
fix(weapongrid): show favorites simultaneously on both sides when selecting them, also don't show favorites for destructive actions

### DIFF
--- a/frontend/src/components/WeaponIcon.vue
+++ b/frontend/src/components/WeaponIcon.vue
@@ -17,6 +17,7 @@
 
       <div class="trait">
         <span :class="weapon.element.toLowerCase() + '-icon'"></span>
+        <b-icon v-if="favorite" class="favorite-star" icon="star-fill" variant="warning" />
       </div>
 
       <div class="name">
@@ -88,7 +89,7 @@ function transformModel(model, y) {
 }
 
 export default {
-  props: ['weapon'],
+  props: ['weapon', 'favorite'],
 
   computed: {
     ...mapState(['maxDurability']),
@@ -477,8 +478,13 @@ export default {
   left: 10px;
 }
 
+.favorite-star {
+  position: absolute;
+  margin-left: 5px;
+}
+
 .id {
-  top: 10px;
+  top: 8px;
   right: 10px;
   font-style: italic;
 }

--- a/frontend/src/components/smart/WeaponGrid.vue
+++ b/frontend/src/components/smart/WeaponGrid.vue
@@ -26,11 +26,22 @@
         <b-check class="show-reforged-checkbox" v-model="showReforgedWeapons" />
         <strong>Show reforged</strong>
       </div>
-       <b-button variant="primary" class="ml-3 clear-filters-button" @click="clearFilters" >
-          <span>
-            Clear Filters
-          </span>
-        </b-button>
+
+      <div v-if="showFavoriteToggle" class="show-reforged show-favorite">
+        <b-check class="show-reforged-checkbox" v-model="showFavoriteWeapons" />
+        <strong>Show Favorite</strong>
+      </div>
+
+      <b-button
+        variant="primary"
+        class="ml-3 clear-filters-button"
+        :class="{ 'mb-4': showReforgedToggle && showFavoriteToggle }"
+        @click="clearFilters"
+      >
+        <span>
+          Clear Filters
+        </span>
+      </b-button>
     </div>
 
     <ul class="weapon-grid">
@@ -42,9 +53,8 @@
         @click="getWeaponDurability(weapon.id) > 0 && onWeaponClick(weapon.id)"
         @contextmenu="canFavorite && toggleFavorite($event, weapon.id)"
       >
-        <b-icon v-if="isFavorite(weapon.id) === true" class="favorite-star" icon="star-fill" variant="warning" />
         <div class="weapon-icon-wrapper">
-          <weapon-icon class="weapon-icon" :weapon="weapon" />
+          <weapon-icon class="weapon-icon" :weapon="weapon" :favorite="isFavorite(weapon.id)" />
         </div>
         <div class="above-wrapper" v-if="$slots.above || $scopedSlots.above">
           <slot name="above" :weapon="weapon"></slot>
@@ -57,6 +67,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import Events from '../../events';
 import { Accessors, PropType } from 'vue/types/options';
 import { mapActions, mapGetters, mapMutations, mapState } from 'vuex';
 import { IState, IWeapon } from '../../interfaces';
@@ -75,9 +86,10 @@ interface StoreMappedActions {
 interface Data {
   starFilter: string;
   elementFilter: string;
-  showReforgedWeapons: boolean;
   favorites: Record<number, boolean>;
   priceSort: string;
+  showReforgedWeapons: boolean;
+  showFavoriteWeapons: boolean;
 }
 
 const sorts = [
@@ -130,6 +142,18 @@ export default Vue.extend({
       type: Boolean,
       default: true,
     },
+    showReforgedWeaponsDefVal: {
+      type: Boolean,
+      default: true,
+    },
+    showFavoriteToggle: {
+      type: Boolean,
+      default: true,
+    },
+    showFavoriteWeaponsDefVal: {
+      type: Boolean,
+      default: true,
+    },
     canFavorite: {
       type: Boolean,
       default: true,
@@ -144,10 +168,11 @@ export default Vue.extend({
     return {
       starFilter: '',
       elementFilter: '',
-      showReforgedWeapons: true,
       favorites: {},
       priceSort: '',
       sorts,
+      showReforgedWeapons: this.showReforgedWeaponsDefVal,
+      showFavoriteWeapons: this.showFavoriteWeaponsDefVal,
     } as Data;
   },
 
@@ -175,9 +200,17 @@ export default Vue.extend({
       let items: IWeapon[] = [];
       this.displayWeapons.forEach((x) => items.push(x));
 
+      const allIgnore: string[] = [];
       if (this.ignore) {
-        items = items.filter((x) => x.id.toString() !== (this.ignore || '').toString());
+        allIgnore.push((this.ignore || '').toString());
       }
+      if (!this.showFavoriteWeapons) {
+        for (const key in this.favorites) {
+          allIgnore.push(key);
+        }
+      }
+      items = items.filter((x) => allIgnore.findIndex((y) => y === x.id.toString()) < 0);
+
 
       if (this.starFilter) {
         items = items.filter((x) => x.stars === +this.starFilter - 1);
@@ -239,6 +272,8 @@ export default Vue.extend({
       }
 
       localStorage.setItem('favorites', this.getFavoritesString(this.favorites));
+
+      Events.$emit('weapon:newFavorite', { value: weaponId });
     },
 
     getFavoritesString(favorites: Record<number, boolean>): string {
@@ -278,10 +313,22 @@ export default Vue.extend({
     onWeaponClick(id: number) {
       this.setCurrentWeapon(id);
       this.$emit('choose-weapon', id);
+    },
+
+    checkStorageFavorite() {
+      const favoritesFromStorage = localStorage.getItem('favorites');
+      if (favoritesFromStorage) {
+        this.favorites = JSON.parse(favoritesFromStorage);
+      }
     }
   },
 
   mounted() {
+
+    this.checkStorageFavorite();
+
+    Events.$on('weapon:newFavorite', () => this.checkStorageFavorite());
+
     if(this.isMarket) {
       this.starFilter = sessionStorage.getItem('market-weapon-starfilter') || '';
       this.elementFilter = sessionStorage.getItem('market-weapon-elementfilter') || '';
@@ -289,11 +336,6 @@ export default Vue.extend({
     } else {
       this.starFilter = sessionStorage.getItem('weapon-starfilter') || '';
       this.elementFilter = sessionStorage.getItem('weapon-elementfilter') || '';
-    }
-
-    const favoritesFromStorage = localStorage.getItem('favorites');
-    if (favoritesFromStorage) {
-      this.favorites = JSON.parse(favoritesFromStorage);
     }
   },
 });
@@ -357,6 +399,10 @@ export default Vue.extend({
   align-self: center;
 }
 
+.show-favorite {
+    margin-left: 15px;
+  }
+
 .show-reforged-checkbox {
   margin-left: 5px;
 }
@@ -366,23 +412,18 @@ export default Vue.extend({
   height: fit-content;
 }
 
-.favorite-star {
-  position: absolute;
-  bottom: 5px;
-  right: 5px;
+.clear-filters-button {
+  display: flex;
+  flex-direction: row;
+  align-self: center;
 }
-
- .clear-filters-button {
-    display: flex;
-    flex-direction: row;
-    align-self: center;
-  }
 
 @media (max-width: 576px) {
   .weapon-grid {
     justify-content: center;
     margin-top: 10px;
   }
+
   .show-reforged {
     width: 100%;
     justify-content: center;

--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -107,7 +107,7 @@
           </div>
         </b-modal>
 
-        <weapon-grid v-model="burnWeaponId" :ignore="reforgeWeaponId" />
+        <weapon-grid v-model="burnWeaponId" :ignore="reforgeWeaponId" :showReforgedWeapons="false" :showFavoriteWeapons="false" />
       </div>
     </div>
   </div>

--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -107,7 +107,7 @@
           </div>
         </b-modal>
 
-        <weapon-grid v-model="burnWeaponId" :ignore="reforgeWeaponId" :showReforgedWeapons="false" :showFavoriteWeapons="false" />
+        <weapon-grid v-model="burnWeaponId" :ignore="reforgeWeaponId" :showReforgedWeaponsDefVal="false" :showFavoriteWeaponsDefVal="false" />
       </div>
     </div>
   </div>

--- a/frontend/src/views/Market.vue
+++ b/frontend/src/views/Market.vue
@@ -46,6 +46,7 @@
                 :weaponIds="allSearchResults"
                 :showLimit="weaponShowLimit"
                 :showReforgedToggle="false"
+                :showFavoriteToggle="false"
                 :canFavorite="false"
                 :isMarket="true"
                 v-model="selectedNftId">
@@ -223,6 +224,7 @@
                 v-if="activeType === 'weapon'"
                 :showGivenWeaponIds="true"
                 :showReforgedToggle="false"
+                :showFavoriteToggle="false"
                 :canFavorite="false"
                 :weaponIds="searchResults"
                 :isMarket="true"
@@ -375,7 +377,8 @@
             <div class="sell-grid" v-if="activeType === 'weapon'">
               <weapon-grid
                 v-model="selectedNftId"
-                :showReforgedToggle="false"
+                :showReforgedWeaponsDefVal="false"
+                :showFavoriteWeaponsDefVal="false"
                 :canFavorite="false"
               />
             </div>


### PR DESCRIPTION
### All Submissions

Default value in 'reforge' mode in 'blacksmith'
![image](https://user-images.githubusercontent.com/1824055/126876474-3ea2f20b-25e6-450e-bb71-56f234420d3c.png)

Default value in 'List NFT' mode in 'market'
![image](https://user-images.githubusercontent.com/1824055/126876483-65f4e1db-d2bc-4cf1-b7ec-80c7f16c8ac6.png)


### New Feature Submissions

Fix #429

+ default not show favorit and reforged weapon in 'reforge' side
+ sync favorite weapon between weaponGrid left and right in reforge mode
+ add 'favorite' checkbox in WeaponGrid
+ default not show favorit and reforged weapon in 'List NFT'

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Improve 'favorite weapon' management in Blacksmith and Market