### PR TITLE
fix(weapon): can now select weapon with 0 durability

### DIFF
--- a/frontend/src/components/smart/WeaponGrid.vue
+++ b/frontend/src/components/smart/WeaponGrid.vue
@@ -50,7 +50,8 @@
         :class="{ selected: highlight !== null && weapon.id === highlight }"
         v-for="weapon in nonIgnoredWeapons"
         :key="weapon.id"
-        @click="getWeaponDurability(weapon.id) > 0 && onWeaponClick(weapon.id)"
+        @click=
+        "(!checkForDurability || getWeaponDurability(weapon.id) > 0) && onWeaponClick(weapon.id)"
         @contextmenu="canFavorite && toggleFavorite($event, weapon.id)"
       >
         <div class="weapon-icon-wrapper">
@@ -161,7 +162,11 @@ export default Vue.extend({
     isMarket: {
       type: Boolean,
       default: false
-    }
+    },
+    checkForDurability: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data() {

--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -54,7 +54,7 @@
                 </b-button>
               </div>
 
-              <weapon-grid v-if="!selectedWeaponId" v-model="selectedWeaponId" />
+              <weapon-grid v-if="!selectedWeaponId" v-model="selectedWeaponId" checkForDurability="true" />
 
             </div>
             <div class="row mb-3 flex-column enemy-container" v-if="targets.length > 0">


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
* [x] #433 

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Weapon cards couldn't be clicked if weapon durability was 0 (or undefined due to #446). This should only happen when choosing a weapon for combat.
Added a checkForDurability bool that defaults to false and is only sent when showing weapons for combat.

Note: shared effort with @ertsybot 