### PR TITLE
Add support for premium and loot weapon minting

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -428,7 +428,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
         // first weapon free with a character mint, max 1 star
         if(weapons.balanceOf(msg.sender) == 0) {
             weapons.performMintWeapon(msg.sender,
-                weapons.getRandomProperties(0, RandomUtil.combineSeeds(seed,100)),
+                weapons.getRandomProperties(0, RandomUtil.combineSeeds(seed,100), 0),
                 weapons.getRandomStat(4, 200, seed, 101),
                 0, // stat2
                 0, // stat3
@@ -442,6 +442,20 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
         uint256 seed = randoms.getRandomSeed(msg.sender);
         weapons.mint(msg.sender, seed);
+    }
+
+    function mintLootWeapon() public restricted doesNotHaveMoreThanMaxCharacters oncePerBlock(msg.sender) {
+        _payContract(msg.sender, mintWeaponFee);
+
+        uint256 seed = randoms.getRandomSeed(msg.sender);
+        weapons.mintRareWithAlignment(msg.sender, seed, 1);
+    }
+
+    function mintPremiumWeapon() public onlyNonContract doesNotHaveMoreThanMaxCharacters oncePerBlock(msg.sender) requestPayFromPlayer(mintWeaponFee * 5) {
+        _payContract(msg.sender, mintWeaponFee);
+
+        uint256 seed = randoms.getRandomSeed(msg.sender);
+        weapons.mintRareWithAlignment(msg.sender, seed, 0);
     }
 
     function burnWeapon(uint256 burnID) public

--- a/contracts/raidBasic.sol
+++ b/contracts/raidBasic.sol
@@ -95,7 +95,7 @@ contract RaidBasic is Initializable, Raid {
     }
 
     function mintRewardWeapon(uint256 stars, uint256 seed) public restricted {
-        uint256 tokenId = weapons.mintWeaponWithStars(address(game), stars, seed);
+        uint256 tokenId = weapons.mintWeaponWithStars(address(game), stars, seed, 1);
         addRewardWeapon(tokenId);
     }
 


### PR DESCRIPTION
This change does the following:
- adds public restricted mintRareWithAlignment() to weapons.sol
- adds public restricted mintLootWeapon() to cryptoblades.sol
- adds public mintPremiumWeapon() to cryptoblades.sol for 5x the cost of mintWeapon()
- updates mintRewardWeapon() to use minimumStatsAligned=1 in raidBasic.sol