### PR TITLE
fix(market): weapon durability display

### DIFF
--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -864,7 +864,7 @@ export function createStore(web3: Web3) {
         await Promise.all(weaponIds.map(id => dispatch('fetchWeapon', id)));
       },
 
-      async fetchWeapon({ state, commit }, weaponId: string | number) {
+      async fetchWeapon({ state, commit, dispatch }, weaponId: string | number) {
         const { Weapons } = state.contracts();
         if(!Weapons) return;
 
@@ -878,6 +878,7 @@ export function createStore(web3: Web3) {
             commit('updateWeapon', { weaponId, weapon });
           })(),
         ]);
+        dispatch('fetchWeaponDurability', weaponId);
       },
 
       async setupWeaponDurabilities({ state, dispatch }) {


### PR DESCRIPTION
### All Submissions

* [X] Can you post a screenshot of your changes (if applicable)?
![image](https://user-images.githubusercontent.com/14833808/127678862-a3f2080b-6fef-4071-a8d9-7b0835acd383.png)

### New Feature Submissions

* [X] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
this fixes issue: https://github.com/CryptoBlades/cryptoblades/issues/446

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

This fixes issue of missing or undefined weapon durability in the market. What was happening was, only the owned weapons durability gets push to the state. So all weapons durability's listed in the market needs to be fetched and stored in the state as well.