### PR TITLE
Remove oncePerBlock()-equivalent logic from fightModifierChecks()

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -483,8 +483,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     modifier fightModifierChecks(uint256 char, uint256 wep) {
         require(tx.origin == msg.sender, "Only EOA allowed (temporary)");
         require(characters.balanceOf(msg.sender) <= characters.characterLimit(), "Too many characters owned");
-        require(lastBlockNumberCalled[msg.sender] < block.number, "Only callable once per block");
-        lastBlockNumberCalled[msg.sender] = block.number;
         require(characters.ownerOf(char) == msg.sender, "Not the character owner");
         require(weapons.ownerOf(wep) == msg.sender, "Not the weapon owner");
         _;


### PR DESCRIPTION
The call to `characters.getFightDataAndDrainStamina() in fight() enforces the stamina requirements.

Additionally, nested through _verifyFight() and verifyFight(), the invocation of getTargetsInternal() ensures that the staminaTimestamp impacts the targets when validating the target passed to fight().

Consequently, there is no additional need for oncePerBlock()-equivalent logic in the fight() method.

This change removes this unneeded gas overhead.