### PR TITLE
fix(combat): when validating targets, disable fight button

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -278,16 +278,18 @@ export default {
         return;
       }
 
+      this.waitingResults = true;
+
       // Force a quick refresh of targets
       await this.fetchTargets({ characterId: this.currentCharacterId, weaponId: this.selectedWeaponId });
       // If the targets list no longer contains the chosen target, return so a new target can be chosen
       if (!this.targets.find((target) => target.original === targetToFight.original)) {
+        this.waitingResults = false;
         return;
       }
 
       this.fightResults = null;
       this.error = null;
-      this.waitingResults = true;
       this.setIsInCombat(this.waitingResults);
 
       try {


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
* [x] #548 

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

waitingResults should be set to true before validating targets to disable buttons. Otherwise players with poor internet can click fight button multiple times and end up issuing multiple transactions leading to exceptions and confusion.