### PR TITLE
fix(combat): can no longer fight when weapon would not be able to fight based on stamina multiplier

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -108,7 +108,7 @@
                     <big-button
                       class="encounter-button btn-styled"
                       :mainText="`Fight!`"
-                      :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults"
+                      :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults || !weaponHasDurability(selectedWeaponId)"
                       @click="onClickEncounter(e)"
                     />
                     <p v-if="isLoadingTargets">Loading...</p>


### PR DESCRIPTION
### Description

In views/Combat.vue the setStaminaSelectorValues() method checks only if the fighter can do the battle, so if you have a sword with 1 durability and a fighter with 160, users are able to start a transaction that will later fail (by choosing 40 stamina, 1 durability sword, and then changing the stamina to a greater number). This will potentially make a lot of users lose unnecessary gas, and it will happen more often with the PVP and Raids because of how they work with stamina.

### Screenshots
I've greyed out the fight button when such a thing happens, so now, if your sword does not have the durability, you cannot start a transaction.

![image](https://user-images.githubusercontent.com/15352087/127799370-27961ea9-2069-478a-afea-39cd7353e3e7.png)

### Notes
The "This weapon does not have durability" message still shows, but players were still able to click on "Fight" and start the transaction.

As a suggestion, I would change the max stamina of the fighters to 50, and make every fight cost 10 (also adjust the sword's durability to match). This makes it so players can know how many fights they can do by looking at the tens of their current stamina instead of doing multiplication.



