### PR TITLE
fix(combat): enemy area now wraps/shows properly

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -88,14 +88,14 @@
                 </div>
               </div>
               <div class="enemy-list">
-                <div class="col-lg-3 col-md-6 col-sm-12 col-xs-12 encounter" v-for="(e, i) in targets" :key="i">
+                <div class="enemy-list-child mx-auto encounter" v-for="(e, i) in targets" :key="i">
                   <div class="encounter-container">
                     <div class="enemy-character">
                       <div class="encounter-element">
                         <span :class="getCharacterTrait(e.trait).toLowerCase() + '-icon'" />
                       </div>
 
-                      <div class="mobile-divider mobile-img-adjustment">
+                      <div class="">
                         <img class="mr-auto ml-auto enemy-img" :src="getEnemyArt(e.power)" alt="Enemy" />
                       </div>
 
@@ -108,7 +108,7 @@
                     <big-button
                       class="encounter-button btn-styled"
                       :mainText="`Fight!`"
-                      :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults"
+                      :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults || !weaponHasDurability(selectedWeaponId)"
                       @click="onClickEncounter(e)"
                     />
                     <p v-if="isLoadingTargets">Loading...</p>
@@ -574,6 +574,7 @@ h1 {
   width: 13em;
   position: relative;
   top: 3vw;
+  margin-top: 2em;
 }
 
 .enemy-img {
@@ -581,10 +582,16 @@ h1 {
   top: -50px;
 }
 
-@media (max-width: 1025px) {
+@media (max-width: 1334px) {
   .enemy-list {
-    flex-direction: column;
+    flex-flow: row wrap;
     align-items: center;
+  }
+  .enemy-list > .enemy-list-child{
+     flex-basis: 50%;
+  }
+  .encounter-button {
+    margin-top: 1.35em;
   }
 }
 
@@ -593,8 +600,13 @@ h1 {
   .encounter img {
     width: calc(100% - 60px);
   }
+  .enemy-list{
+    flex-direction:column;
+    align-items:center;
+  }
   .combat-enemy-container {
     flex-direction: column;
+    align-items: center;
   }
   .weapon-selection {
     border-right: none;
@@ -644,10 +656,6 @@ h1 {
     width: 100%;
     justify-content: center;
     display: block;
-  }
-
-  .encounter-button {
-    top: 10vw;
   }
 }
 </style>


### PR DESCRIPTION
### [Issue 559](https://github.com/CryptoBlades/cryptoblades/issues/559)


### Screenshots
Normal Screen
![image](https://user-images.githubusercontent.com/15352087/128098092-1ce13993-ad7f-459d-b4d1-28d25344e0da.png)

Medium
![pr-5592](https://user-images.githubusercontent.com/15352087/128098107-103b71cf-4f67-456f-bc2d-69fe2b0a62f4.png)

Small
![pr-5593](https://user-images.githubusercontent.com/15352087/128098111-52363541-77c9-4f7b-a61b-d86201fbff89.png)


### PR Description

Fixed wrap of enemies on smaller screens, avoiding the following:
![image](https://user-images.githubusercontent.com/15352087/128098207-3b1d3c2a-9b87-43dd-b3d6-da59962c95a1.png)

