### PR TITLE
Earning Calculator fix

### DIFF
--- a/frontend/src/components/smart/EarningsCalculator.vue
+++ b/frontend/src/components/smart/EarningsCalculator.vue
@@ -31,14 +31,9 @@
                   <b-form-input class="stat-input" type="number" v-model="levelSliderValue" :min="1" :max="255" />
                 </div>
                 <span>Stamina</span>
-                <div class="d-flex">
-                <select class="form-control wep-trait-form" v-model="staminaSelectValue">
+                <select class="form-control" v-model="staminaSelectValue">
                   <option v-for="x in [40,80,120,160,200]" :value="x" :key="x">{{ x }}</option>
                 </select>
-                <b-icon-question-circle class="centered-icon mt-1 ml-2 " scale="1.2"
-                  v-tooltip.right="`LowStamina: + SKILL - USD HighStamina: - SKILL + USD
-                                  Increasing stamina spent reduces Gas Offset rewards, however: BnbFees>GasOffset`"/>
-                  </div>
               </div>
 
               <div class="calculator-earnings">
@@ -321,7 +316,8 @@ export default Vue.extend({
     },
 
     getAverageRewardAtLevel(level: number): number {
-      return this.formattedSkill(this.fightGasOffset) + (this.formattedSkill(this.fightBaseline) * (Math.sqrt(CharacterPower(level - 1)/1000)));
+      return this.formattedSkill(this.fight
+      ) + (this.formattedSkill(this.fightBaseline) * (Math.sqrt(CharacterPower(level - 1)/1000)));
     },
 
     getRewardDiffBonus(level: number, targetLevel: number): string {


### PR DESCRIPTION
###  Description

New features for the Earning Calculator

- Added stamina selector
- Added tooltip

### Notes
Earnings are calculated in a very confusing way, I took the gas offset away from power reward calculation, and reimplemented it depending on the number of fights, which depend on the stamina selector.

Calculator now considers a 'day' as 7.2 fights, which will essentially mean bigger numbers overall for the users.

### Screenshots

![image](https://user-images.githubusercontent.com/18062272/128229446-c7218ba1-475e-4849-84f8-5dcc1bbb1024.png)

-Tooltip
![image](https://user-images.githubusercontent.com/18062272/128229518-4e836a41-b90c-4fa4-ad8e-1889188f2397.png)

