### PR TITLE
fix(calculator): improve calculator with stamina selector

### DIFF
--- a/frontend/src/components/smart/EarningsCalculator.vue
+++ b/frontend/src/components/smart/EarningsCalculator.vue
@@ -30,6 +30,10 @@
                   <input class="stat-slider" type="range" min="1" max="255" v-model="levelSliderValue" />
                   <b-form-input class="stat-input" type="number" v-model="levelSliderValue" :min="1" :max="255" />
                 </div>
+                <span>Stamina</span>
+                <select class="form-control wep-trait-form" v-model="staminaSelectValue">
+                  <option v-for="x in [40,80,120,160,200]" :value="x" :key="x">{{ x }}</option>
+                </select>
               </div>
 
               <div class="calculator-earnings">
@@ -170,6 +174,7 @@ export default Vue.extend({
     return {
       characterElementValue: '',
       levelSliderValue: 1,
+      staminaSelectValue: 40,
       starsValue: 1,
       wepElementValue: '',
       wepFirstStatElementValue: '',
@@ -211,6 +216,7 @@ export default Vue.extend({
     onReset() {
       this.characterElementValue = '';
       this.levelSliderValue =  1;
+      this.staminaSelectValue = 40;
       this.starsValue =  1;
       this.wepElementValue =  '';
       this.wepFirstStatElementValue =  '';
@@ -263,16 +269,23 @@ export default Vue.extend({
       const weapon = this.getWeapon();
       const characterTrait = CharacterTrait[this.characterElementValue as keyof typeof CharacterTrait];
       const weaponMultiplier = GetTotalMultiplierForTrait(weapon, characterTrait);
+      const fights = this.getNumberOfFights(this.staminaSelectValue);
 
       const totalPower = this.getTotalPower(CharacterPower(this.levelSliderValue - 1), weaponMultiplier, this.wepBonusPowerSliderValue);
-      const averageReward = this.getAverageRewardForPower(totalPower);
-      const averageFightProfit = averageReward * this.skillPrice - fightBnbFee;
+      const averageDailyReward = this.getAverageRewardForPower(totalPower) *7.2 +
+        this.formattedSkill(this.fightGasOffset) * fights;
+      const averageFightProfit = averageDailyReward * this.skillPrice / 7.2;
       for(let i = 1; i < 8; i++) {
-        const averageDailyProfitForCharacter = averageFightProfit * i - (7 - i) * fightBnbFee;
+        const averageDailyProfitForCharacter = averageFightProfit * i -
+          ((this.getNumberOfFights(this.staminaSelectValue) * fightBnbFee));
         const averageDailyProfitForAllCharacter = 4 * averageDailyProfitForCharacter;
         const averageMonthlyProfitForAllCharacter = 30 * averageDailyProfitForAllCharacter;
         this.calculationResults.push([averageDailyProfitForCharacter, averageDailyProfitForAllCharacter, averageMonthlyProfitForAllCharacter]);
       }
+    },
+
+    getNumberOfFights(stamina: number) {
+      return 288 / stamina;
     },
 
     getWeapon(): IWeapon {
@@ -292,7 +305,7 @@ export default Vue.extend({
     },
 
     getAverageRewardForPower(power: number): number {
-      return this.formattedSkill(this.fightGasOffset) + (this.formattedSkill(this.fightBaseline) * Math.sqrt(power / 1000));
+      return (this.formattedSkill(this.fightBaseline) * Math.sqrt(power / 1000));
     },
 
     getNextMilestoneBonus(level: number): string {


### PR DESCRIPTION
###  Description

New features for the Earning Calculator:

- Added stamina selector
- Considered stamina into earnings calculator

### Notes
Earnings are calculated in a very confusing way, I took the gas offset away from power reward calculation, and reimplemented it depending on the number of fights, which depend on the stamina selector.

Calculator now considers a 'day' as 7.2 fights, which will essentially mean bigger numbers overall for the users.

[Issue](https://github.com/CryptoBlades/cryptoblades/issues/569)

Previous [PR](https://github.com/CryptoBlades/cryptoblades/pull/596) had big diffs, closed it and, made a new one for easier readability.

### Screenshots

![image](https://user-images.githubusercontent.com/18062272/128256337-aba3554e-5ca6-4841-a564-0b79240810d6.png)

