### PR TITLE
Market slicing view

### DIFF
--- a/contracts/NFTMarket.sol
+++ b/contracts/NFTMarket.sol
@@ -415,23 +415,24 @@ contract NFTMarket is
             );
     }
 
-    function getListingSlice(address _tokenAddress, uint256 start, uint256 length)
+    function getListingSlice(IERC721 _tokenAddress, uint256 start, uint256 length)
         public
         view
-        returns (uint256[] memory ids, address[] memory sellers, uint256[] memory prices)
+        returns (uint256 returnedCount, uint256[] memory ids, address[] memory sellers, uint256[] memory prices)
     {
+        returnedCount = length;
         ids = new uint256[](length);
         sellers = new address[](length);
         prices = new uint256[](length);
 
         uint index = 0;
-        EnumerableSet.UintSet storage listedTokens = listedTokenIDs[_tokenAddress];
-        for(uint i = start; i <= start+length; i++) {
-            if(i + 1 > listedTokens.length())
-                return(ids, sellers, prices);
-            
+        EnumerableSet.UintSet storage listedTokens = listedTokenIDs[address(_tokenAddress)];
+        for(uint i = start; i < start+length; i++) {
+            if(i >= listedTokens.length())
+                return(index, ids, sellers, prices);
+
             uint256 id = listedTokens.at(i);
-            Listing memory listing = listings[_tokenAddress][id];
+            Listing memory listing = listings[address(_tokenAddress)][id];
             ids[index] = id;
             sellers[index] = listing.seller;
             prices[index++] = listing.price;

--- a/contracts/NFTMarket.sol
+++ b/contracts/NFTMarket.sol
@@ -415,6 +415,29 @@ contract NFTMarket is
             );
     }
 
+    function getListingSlice(address _tokenAddress, uint256 start, uint256 length)
+        public
+        view
+        returns (uint256[] memory ids, address[] memory sellers, uint256[] memory prices)
+    {
+        ids = new uint256[](length);
+        sellers = new address[](length);
+        prices = new uint256[](length);
+
+        uint index = 0;
+        EnumerableSet.UintSet storage listedTokens = listedTokenIDs[_tokenAddress];
+        for(uint i = start; i <= start+length; i++) {
+            if(i + 1 > listedTokens.length())
+                return(ids, sellers, prices);
+            
+            uint256 id = listedTokens.at(i);
+            Listing memory listing = listings[_tokenAddress][id];
+            ids[index] = id;
+            sellers[index] = listing.seller;
+            prices[index++] = listing.price;
+        }
+    }
+
     // ############
     // Mutative
     // ############

--- a/migrations/60_market_slicing_view.js
+++ b/migrations/60_market_slicing_view.js
@@ -1,0 +1,7 @@
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+
+const NFTMarket = artifacts.require("NFTMarket");
+
+module.exports = async function (deployer, network, accounts) {
+  await upgradeProxy(NFTMarket.address, NFTMarket, { deployer });
+};


### PR DESCRIPTION
As requested by smoke, this lets us scrape the market little by little without blasting the nodes.

There's an intentional return with default (0) values on indices that fall out of the listing array's bounds, so that the length doesnt have to be perfect for the topmost slice, as it may be changing rapidly.
