### PR TITLE
fix(forge): change how buttons become enabled again

### DIFF
--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -307,9 +307,10 @@ export default {
       this.x1Forge = true;
       this.disableForge = true;
 
-      setTimeout(() => {
+      // Incase the network or mm are having issues, after 1 min we reshow
+      const failbackTimeout = setTimeout(() => {
         this.disableForge = false;
-      }, 10000);
+      }, 60000);
 
       try {
         await this.mintWeapon();
@@ -318,6 +319,9 @@ export default {
         console.error(e);
         this.onError = true;
         this.$dialog.notify.error('Could not forge sword: insuffucient funds or transaction denied.');
+      } finally {
+        clearTimeout(failbackTimeout);
+        this.disableForge = false;
       }
 
       this.viewNewWeapons(1);
@@ -331,9 +335,10 @@ export default {
       this.onError = false;
       this.x10Forge = true;
 
-      setTimeout(() => {
+      // Incase the network or mm are having issues, after 1 min we reshow
+      const failbackTimeout = setTimeout(() => {
         this.disableForge = false;
-      }, 10000);
+      }, 60000);
 
       try {
         await this.mintWeaponN({num: this.forgeMultiplier});
@@ -342,6 +347,9 @@ export default {
         console.error(e);
         this.onError = true;
         this.$dialog.notify.error('Could not forge sword: insuffucient funds or transaction denied.');
+      } finally {
+        clearTimeout(failbackTimeout);
+        this.disableForge = false;
       }
 
       this.viewNewWeapons(this.forgeMultiplier);


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)? **Just changed when the forge buttons become reactive, not how they are displayed.**

### New Feature Submissions

* [x] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)? **Yes, Issue #583**

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Adds block to reenable forge after transactions are done (successful or failed). 

Kept original timed event in, but with a longer time, incase there are issues with network/mm. Thought that might be nice in certain cases. Though may want that to be longer, or decide its not an issue as the user could just reload the page anyway.