### PR TITLE
fix(combat) - Disallow invalid fight

### DIFF
--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -112,7 +112,7 @@
                 <big-button
                       class="encounter-button btn-styled"
                       :mainText="`Fight!`"
-                      :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults || !weaponHasDurability(selectedWeaponId)"
+                      :disabled="(timeMinutes === 59 && timeSeconds >= 30) || waitingResults || !weaponHasDurability(selectedWeaponId) || !charHasStamina()"
                       @click="onClickEncounter(e)"
                     />
                 <p v-if="isLoadingTargets">Loading...</p>
@@ -223,6 +223,9 @@ export default {
     getEnemyArt,
     weaponHasDurability(id) {
       return this.getWeaponDurability(id) >= this.fightMultiplier;
+    },
+    charHasStamina(){
+      return this.currentCharacterStamina >= this.staminaPerFight;
     },
     getCharacterTrait(trait) {
       return CharacterTrait[trait];


### PR DESCRIPTION
### [Issue](https://github.com/CryptoBlades/cryptoblades/issues/535)

### Description
This issue can still happen. Players can start an invalid transaction if they start combat with 200 stamina, then select to spend 120. After winning/losing the fightMultiplier value does not change, even though it is not rendered because of  setStaminaSelectorValues()
### Screenshots

It looks like this when the bug happens
![image](https://user-images.githubusercontent.com/15352087/128582378-f982ff3d-4937-44de-bec7-8296a697d660.png)
Notice stamina cost per fight is blank, but players can still click on fight.
### PR Description
This simple fix disallows for such a thing to happen, when they reach this state, players will be sent back to this screen
![image](https://user-images.githubusercontent.com/15352087/128582602-e521913f-5c93-43ff-9b20-632f97b3c276.png)
