### PR TITLE
fix(metamask): refresh store after metamask is initialized

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -277,6 +277,9 @@ export default {
         .then(() => {
           this.errorMessage = 'Success: MetaMask connected.';
           this.isConnecting = false;
+
+          this.initializeStore();
+          this.toggleHideWalletWarning();
         })
         .catch(() => {
           this.errorMessage = 'Error: MetaMask could not get permissions.';


### PR DESCRIPTION
### All Submissions

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?.
https://github.com/CryptoBlades/cryptoblades/issues/180

### PR Description

 - Re initialize state when metamask is connected
 - Hide warning modal