### PR TITLE
load market taxes when switching to search tab

### DIFF
--- a/frontend/src/views/Market.vue
+++ b/frontend/src/views/Market.vue
@@ -195,7 +195,7 @@
         </div>
       </b-tab>
 
-      <b-tab @click="clearData(),browseTabActive = false;skillShopTabActive = false">
+      <b-tab @click="clearData();loadMarketTaxes(),browseTabActive = false;skillShopTabActive = false">
         <template #title>
           Search NFTs
           <hint class="hint" text="NFT stands for Non Fungible Token.<br>Weapons, Shields and Characters are NFTs of the ERC721 standard" />


### PR DESCRIPTION
### All Submissions
Fixes this bug. (fixes issue 665)
![image](https://user-images.githubusercontent.com/5601589/129462578-e6a21ee4-9e3e-4571-86bf-c4f8053a8838.png)


### PR Description

This fixes #665. The market tax is not set when not coming from the listing tab, because that's the only time this.weaponMarketTax is set. This fix loads the market tax, when selecting the 'Search NFTs' tab, by calling loadMarketTax().