### PR TITLE
trait change events fix

### DIFF
--- a/contracts/CharacterEarthTraitChangeConsumables.sol
+++ b/contracts/CharacterEarthTraitChangeConsumables.sol
@@ -25,7 +25,7 @@ contract CharacterEarthTraitChangeConsumables is Consumables {
     function changeCharacterTrait(uint256 characterId) public {
         require(characters.ownerOf(characterId) == msg.sender, "Not the character owner");
         consumeItem(1);
-        characters.setTrait(characterId, 1);
         emit CharacterTraitChangedToEarth(msg.sender, characterId, characters.getTrait(characterId));
+        characters.setTrait(characterId, 1);
     }
 }

--- a/contracts/CharacterFireTraitChangeConsumables.sol
+++ b/contracts/CharacterFireTraitChangeConsumables.sol
@@ -25,7 +25,7 @@ contract CharacterFireTraitChangeConsumables is Consumables {
     function changeCharacterTrait(uint256 characterId) public {
         require(characters.ownerOf(characterId) == msg.sender, "Not the character owner");
         consumeItem(1);
-        characters.setTrait(characterId, 0);
         emit CharacterTraitChangedToFire(msg.sender, characterId, characters.getTrait(characterId));
+        characters.setTrait(characterId, 0);
     }
 }

--- a/contracts/CharacterLightningTraitChangeConsumables.sol
+++ b/contracts/CharacterLightningTraitChangeConsumables.sol
@@ -25,7 +25,7 @@ contract CharacterLightningTraitChangeConsumables is Consumables {
     function changeCharacterTrait(uint256 characterId) public {
         require(characters.ownerOf(characterId) == msg.sender, "Not the character owner");
         consumeItem(1);
-        characters.setTrait(characterId, 2);
         emit CharacterTraitChangedToLightning(msg.sender, characterId, characters.getTrait(characterId));
+        characters.setTrait(characterId, 2);
     }
 }

--- a/contracts/CharacterWaterTraitChangeConsumables.sol
+++ b/contracts/CharacterWaterTraitChangeConsumables.sol
@@ -25,7 +25,7 @@ contract CharacterWaterTraitChangeConsumables is Consumables {
     function changeCharacterTrait(uint256 characterId) public {
         require(characters.ownerOf(characterId) == msg.sender, "Not the character owner");
         consumeItem(1);
-        characters.setTrait(characterId, 3);
         emit CharacterTraitChangedToWater(msg.sender, characterId, characters.getTrait(characterId));
+        characters.setTrait(characterId, 3);
     }
 }


### PR DESCRIPTION
Previously, trait changes were mistakenly doing the previous trait lookup for the emitted event after it had already been changed.
This fixes that by pushing the event before the change.