### PR TITLE
Stop deduction and transfer of zero in _deductPlayerSkillStandard()

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -1068,11 +1068,18 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
         uint256 fromTokenRewards,
         uint256 fromUserWallet
     ) internal {
-        totalInGameOnlyFunds = totalInGameOnlyFunds.sub(fromInGameOnlyFunds);
-        inGameOnlyFunds[playerAddress] = inGameOnlyFunds[playerAddress].sub(fromInGameOnlyFunds);
+        if(fromInGameOnlyFunds > 0) {
+            totalInGameOnlyFunds = totalInGameOnlyFunds.sub(fromInGameOnlyFunds);
+            inGameOnlyFunds[playerAddress] = inGameOnlyFunds[playerAddress].sub(fromInGameOnlyFunds);
+        }
 
-        tokenRewards[playerAddress] = tokenRewards[playerAddress].sub(fromTokenRewards);
-        skillToken.transferFrom(playerAddress, address(this), fromUserWallet);
+        if(fromTokenRewards > 0) {
+            tokenRewards[playerAddress] = tokenRewards[playerAddress].sub(fromTokenRewards);
+        }
+
+        if(fromUserWallet > 0) {
+            skillToken.transferFrom(playerAddress, address(this), fromUserWallet);
+        }
     }
 
     function _payPlayer(address playerAddress, int128 baseAmount) internal {


### PR DESCRIPTION
Noticed when looking at `mintWeapon()` scraping results that showed transfers of zero (ERC-20) Skill.