### PR TITLE
Fix stamina hours cost and SKILL display in raid view

### DIFF
--- a/frontend/src/utils/date-time.ts
+++ b/frontend/src/utils/date-time.ts
@@ -31,3 +31,11 @@ export function secondsToDDHHMMSS (sec: number) {
   return `${days !== 0 && ('0' + days).slice(-2) + 'd ' || ''}` + `${hours !== 0 && ('0' + hours).slice(-2) + 'h ' || ''}` +
     `${minutes !== 0 &&('0' + minutes).slice(-2) + 'm ' || ''}` + `${seconds !== 0 && ('0' + seconds).slice(-2) + 's' || ''}`;
 }
+
+export function staminaToMinutes(stamina: number) {
+  return stamina * 5;
+}
+
+export function staminaToHours(stamina: number) {
+  return staminaToMinutes(stamina) / 60;
+}

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -105,7 +105,7 @@
             stamina </span>,
             <span class="badge badge-secondary">{{ durabilityCost }}
             durability </span> and
-            <span class="badge badge-secondary">{{ joinCost }}SKILL</span>
+            <span class="badge badge-secondary"><CurrencyConverter :skill="convertWeiToSkill(joinCost)" :skill-min-decimals="1"/></span>
           </div>
         </div>
       </div>
@@ -164,7 +164,8 @@
               <nft-list v-if="!spin" :showGivenNftIdTypes="true" :nftIdTypes="rewards" :isReward="true"/>
             </b-modal>
             <div v-bind:class="claimButtonActive ? 'col-sm-3' : 'col-sm-4'">
-              <big-button class="encounter-button btn-styled" :mainText="`Sign up!`" v-tooltip="'Joining will cost 12h of stamina'" @click="joinRaidMethod()" />
+              <big-button class="encounter-button btn-styled" :mainText="`Sign up!`"
+                          v-tooltip="`Joining will cost ${formatStaminaHours}h of stamina`" @click="joinRaidMethod()" />
             </div>
             <div v-bind:class="claimButtonActive ? 'col-sm-3' : 'col-sm-4'">
              <div class="float-lg-right text-sm-center mt-sm-2 text-center">
@@ -192,6 +193,10 @@ import { GetTotalMultiplierForTrait } from '@/interfaces/Weapon';
 import { CharacterPower } from '@/interfaces';
 import { getBossArt } from '@/raid-boss-art-placeholder';
 import { traitNumberToName } from '@/contract-models';
+import CurrencyConverter from '@/components/CurrencyConverter';
+import {fromWeiEther} from '@/utils/common';
+import {staminaToHours} from '@/utils/date-time';
+
 
 let interval = null;
 
@@ -268,6 +273,10 @@ export default {
 
     getSelectedWeapon() {
       return this.ownWeapons.find(x => x.id === this.selectedWeaponId);
+    },
+
+    formatStaminaHours() {
+      return staminaToHours(this.staminaCost).toFixed(1);
     }
   },
 
@@ -279,6 +288,10 @@ export default {
       'fetchIsRaidStarted', 'fetchHaveEnoughEnergy', 'fetchIsCharacterRaiding', 'fetchIsWeaponRaiding','fetchCharacters']),
     ...mapMutations(['setCurrentCharacter']),
     ...mapGetters(['getRaidState']),
+
+    convertWeiToSkill(wei) {
+      return fromWeiEther(wei);
+    },
 
     weaponHasDurabilit(id) {
       return this.getWeaponDurability(id) > 0;
@@ -486,6 +499,7 @@ export default {
   },
 
   components: {
+    CurrencyConverter,
     BigButton,
     CharacterList,
     WeaponGrid,


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?
![image](https://user-images.githubusercontent.com/34208222/131216830-f83a8975-e79b-4a29-8ad4-a22fa736d53d.png)
![image](https://user-images.githubusercontent.com/34208222/131216843-3e566f2a-3998-441f-a1e0-c312f94cd40f.png)


### New Feature Submissions

* [x] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
It's not linked to existing issue, it was talked about in a Discord discussion.

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

My PR involves changes that fix a problem with displaying SKILL cost for raid entry (it is now shown correctly and can now also be shown in USD), as well as removing a hard-coded value for 12h "stamina cost" for raid, it now calculates from provided staminaCost units per raid.