### PR TITLE
raid-and-weapon-ui-fixes

### DIFF
--- a/frontend/src/components/CurrencyConverter.vue
+++ b/frontend/src/components/CurrencyConverter.vue
@@ -8,34 +8,34 @@
 </template>
 
 <script lang="ts">
-
 import Vue from 'vue';
-import {toBN} from '@/utils/common';
+import { toBN } from '@/utils/common';
 import Events from '@/events';
-import {mapState} from 'vuex';
+import { mapState } from 'vuex';
+import BigNumber from 'bignumber.js';
 
 export default Vue.extend({
   props: {
     skill: {
       type: String,
-      default: '0'
+      default: '0',
     },
     skillMinDecimals: {
       type: Number,
-      default: 2
+      default: 2,
     },
     skillMaxDecimals: {
       type: Number,
-      default: 4
+      default: 4,
     },
     usdDecimals: {
       type: Number,
-      default: 2
+      default: 2,
     },
     showValueInSkillOnly: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
   data() {
     return {
@@ -45,7 +45,7 @@ export default Vue.extend({
   computed: {
     ...mapState(['skillPriceInUsd']),
     formattedUsd(): string {
-      return `$${(this.calculateSkillPriceInUsd()).toFixed(this.usdDecimals)}`;
+      return `$${this.calculateSkillPriceInUsd().toFixed(this.usdDecimals)}`;
     },
     formattedSkill(): string {
       return `${this.calculateSkillWithDecimals()} SKILL`;
@@ -53,23 +53,32 @@ export default Vue.extend({
   },
   methods: {
     calculateSkillPriceInUsd(): number {
-      return this.skill as unknown as number * this.skillPriceInUsd as unknown as number;
+      return ((this.skill as unknown as number) *
+        this.skillPriceInUsd) as unknown as number;
     },
     calculateSkillWithDecimals(): string {
       const parsedSkill = toBN(this.skill);
+      const decimalPlaces = this.countDecimalPlaces(parsedSkill);
 
-      if (parsedSkill < toBN(Math.pow(10, -this.skillMaxDecimals))) {
-        return '< ' + Math.pow(10, -this.skillMaxDecimals).toFixed(this.skillMaxDecimals);
+      if (this.skillMaxDecimals < decimalPlaces) {
+        return `~${parsedSkill.toFixed(this.skillMaxDecimals)}`;
       }
 
-      for (let i = this.skillMaxDecimals - 1; i >= this.skillMinDecimals; i--) {
-        if (parsedSkill < toBN(Math.pow(10, -i))) {
-          return parsedSkill.toFixed(i + 1);
-        }
+      if (
+        decimalPlaces > this.skillMinDecimals &&
+        decimalPlaces <= this.skillMaxDecimals
+      ) {
+        return parsedSkill.toString();
       }
 
       return parsedSkill.toFixed(this.skillMinDecimals);
     },
+
+    countDecimalPlaces(value: BigNumber) {
+      if (Math.floor(+value.valueOf()).toString() === value.valueOf()) return 0;
+      return value.toString().split('.')[1].length || 0;
+    },
+
     checkStorage() {
       this.showValueInUsd = localStorage.getItem('showSkillInUsd') === 'true';
     },
@@ -82,5 +91,4 @@ export default Vue.extend({
 </script>
 
 <style>
-
 </style>

--- a/frontend/src/components/WeaponIcon.vue
+++ b/frontend/src/components/WeaponIcon.vue
@@ -489,7 +489,7 @@ export default {
 
 .favorite-star {
   position: absolute;
-  margin-left: 40px;
+  margin-left: 110px;
 }
 
 .id {

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -123,7 +123,7 @@
             stamina </span>,
             <span class="badge badge-secondary">{{ durabilityCost }}
             durability </span> and
-            <span class="badge badge-secondary"><CurrencyConverter :skill="convertWeiToSkill(joinCost)" :skill-min-decimals="1"/></span>
+            <span class="badge badge-secondary"><CurrencyConverter :skill="convertWeiToSkill(joinCost)" :skillMinDecimals="0" :skillMaxDecimals="5"/></span>
           </div>
         </div>
       </div>
@@ -349,7 +349,7 @@ export default Vue.extend({
     ]) as RaidMappedGetters),
 
     calculateWinChance(): string {
-      return (Math.min(Math.max(+this.totalPower / +this.bossPower / 2 * 100, 1), 99)).toFixed(0);
+      return (Math.min(Math.max(+this.totalPower / +this.bossPower / 2 * 100, 0), 99.99)).toFixed(2);
     },
 
     calculateProgressBarColor(): string {


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?
![image](https://user-images.githubusercontent.com/34208222/131708160-37c22d7b-78b5-4317-ba25-0224bd964f9e.png)
![image](https://user-images.githubusercontent.com/34208222/131708526-efc7fd61-cb8c-42e4-b5dc-9a2eb7646b22.png)
![image](https://user-images.githubusercontent.com/34208222/131708552-fa93a06b-95a5-44e8-8f21-9c1127f758b7.png)

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

My PR includes changes that fix the following:
- misplaced star on "favourite weapon" - star, when the ID was longer, was covering the ID, now the star is on the right
- victory chance progress bar - now shows % in format XX.XX%, because changes are sometimes small and we need bigger precision, also fixed min and max values of the progress bar
- skill conversion - skill was converted incorrectly in Raid view, it now shows up correctly, in addition, when we restrict SKILL decimal places shown, symbol "~" shows up to indicate that real SKILL price might differ a bit