### PR TITLE
Shrink main contract

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -740,10 +740,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
         _payPlayerConverted(playerAddress, convertedAmount);
     }
 
-    function approveContractWeaponFor(uint256 weaponID, address playerAddress) public restricted {
-        _approveContractWeaponFor(weaponID, playerAddress);
-    }
-
     function payContractTokenOnly(address playerAddress, uint256 convertedAmount) public restricted {
         _payContractTokenOnly(playerAddress, convertedAmount);
     }
@@ -844,14 +840,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
     function _payPlayerConverted(address playerAddress, uint256 convertedAmount) internal {
         skillToken.safeTransfer(playerAddress, convertedAmount);
-    }
-
-    function _approveContractCharacterFor(uint256 characterID, address playerAddress) internal {
-        characters.approve(playerAddress, characterID);
-    }
-
-    function _approveContractWeaponFor(uint256 weaponID, address playerAddress) internal {
-        weapons.approve(playerAddress, weaponID);
     }
 
     function setCharacterMintValue(uint256 cents) public restricted {

--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -26,11 +26,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     int128 public constant PAYMENT_USING_STAKED_SKILL_COST_AFTER_DISCOUNT =
         14757395258967641292; // 0.8 in fixed-point 64x64 format
 
-    // Payment must be recent enough that the hash is available for the payment block.
-    // Use 200 as a 'friendly' window of "You have 10 minutes."
-    uint256 public constant MINT_PAYMENT_TIMEOUT = 200;
-    uint256 public constant MINT_PAYMENT_RECLAIM_MINIMUM_WAIT_TIME = 3 hours;
-
     Characters public characters;
     Weapons public weapons;
     IERC20 public skillToken;//0x154A9F9cbd3449AD22FDaE23044319D6eF2a1Fab;
@@ -179,8 +174,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
     event FightOutcome(address indexed owner, uint256 indexed character, uint256 weapon, uint32 target, uint24 playerRoll, uint24 enemyRoll, uint16 xpGain, uint256 skillGain);
     event InGameOnlyFundsGiven(address indexed to, uint256 skillAmount);
-    event MintWeaponsSuccess(address indexed minter, uint32 count);
-    event MintWeaponsFailure(address indexed minter, uint32 count);
 
     function recoverSkill(uint256 amount) public {
         require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not admin");
@@ -699,7 +692,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     }
 
     function _isSupportedElement(uint8 element) internal pure {
-        require(element == 100 || (element>= 0 && element<= 3), "Not supported element");
+        require(element == 100 || (element>= 0 && element<= 3));
     }
 
     modifier isWeaponOwner(uint256 weapon) {
@@ -708,7 +701,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     }
 
     function _isWeaponOwner(uint256 weapon) internal view {
-        require(weapons.ownerOf(weapon) == msg.sender, "Not the weapon owner");
+        require(weapons.ownerOf(weapon) == msg.sender);
     }
 
     modifier isWeaponsOwner(uint256[] memory weaponArray) {
@@ -718,7 +711,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
     function _isWeaponsOwner(uint256[] memory weaponArray) internal view {
         for(uint i = 0; i < weaponArray.length; i++) {
-            require(weapons.ownerOf(weaponArray[i]) == msg.sender, "Not the weapon owner");
+            require(weapons.ownerOf(weaponArray[i]) == msg.sender);
         }
     }
 
@@ -728,7 +721,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     }
 
     function _isCharacterOwner(uint256 character) internal view {
-        require(characters.ownerOf(character) == msg.sender, "Not the character owner");
+        require(characters.ownerOf(character) == msg.sender);
     }
 
     modifier isTargetValid(uint256 character, uint256 weapon, uint32 target) {
@@ -903,18 +896,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
     function setFightXpGain(uint256 average) public restricted {
         fightXpGain = average;
-    }
-
-    function setCharacterLimit(uint256 max) public restricted {
-        characters.setCharacterLimit(max);
-    }
-
-    function setRewardsClaimTaxMax(int128 _rewardsClaimTaxMax) public restricted {
-        rewardsClaimTaxMax = _rewardsClaimTaxMax;
-    }
-
-    function setRewardsClaimTaxMaxAsRational(uint256 _numerator, uint256 _denominator) public restricted {
-        rewardsClaimTaxMax = ABDKMath64x64.divu(_numerator, _denominator);
     }
 
     function setRewardsClaimTaxMaxAsPercent(uint256 _percent) public restricted {

--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -239,22 +239,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
         );
     }
 
-    function getMyCharacters() public view returns(uint256[] memory) {
-        uint256[] memory tokens = new uint256[](characters.balanceOf(msg.sender));
-        for(uint256 i = 0; i < tokens.length; i++) {
-            tokens[i] = characters.tokenOfOwnerByIndex(msg.sender, i);
-        }
-        return tokens;
-    }
-
-    function getMyWeapons() public view returns(uint256[] memory) {
-        uint256[] memory tokens = new uint256[](weapons.balanceOf(msg.sender));
-        for(uint256 i = 0; i < tokens.length; i++) {
-            tokens[i] = weapons.tokenOfOwnerByIndex(msg.sender, i);
-        }
-        return tokens;
-    }
-
     function unpackFightData(uint96 playerData)
         public pure returns (uint8 charTrait, uint24 basePowerLevel, uint64 timestamp) {
 

--- a/contracts/raid.sol
+++ b/contracts/raid.sol
@@ -9,6 +9,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 abstract contract Raid is Initializable, MultiAccessUpgradeable {
 
+    // THIS AND raidBasic.sol are old unused files, DO NOT USE!
+
     // Outline raids contract that we can iterate on and deploy multiple of.
     // Needs to be granted access to NFT contracts to interact with them
 

--- a/contracts/raidBasic.sol
+++ b/contracts/raidBasic.sol
@@ -6,6 +6,8 @@ import "./raid.sol";
 
 contract RaidBasic is Initializable, Raid {
 
+    // THIS AND raid.sol are old unused files, DO NOT USE!
+
     using ABDKMath64x64 for int128;
     using ABDKMath64x64 for uint256;
 
@@ -29,19 +31,12 @@ contract RaidBasic is Initializable, Raid {
         require(characters.ownerOf(characterID) == msg.sender);
         require(weapons.ownerOf(weaponID) == msg.sender);
         require(participation[characterID] == false, "This character is already part of the raid");
-        require(characters.getStaminaPoints(characterID) > 0, "You cannot join with 0 stamina");
 
         participation[characterID] = true;
         // we drain ~12h of stamina from the character
         // we may want to have a specific lockout in the future
-        characters.setStaminaTimestamp(characterID, uint64(now + (staminaDrain)));
-        // TODO fix raids
-        int128 traitMultiplier = 0;/*game.getPlayerTraitBonusAgainst(
-            characters.getTrait(characterID),
-            weapons.getTrait(weaponID),
-            bossTrait
-        );*/
-        uint24 power = 0;//uint24(traitMultiplier.mulu(game.getPlayerFinalPower(characterID, weaponID)));
+        int128 traitMultiplier = 0;
+        uint24 power = 0;
         totalPower += power;
         raiders.push(Raider(uint256(msg.sender), characterID, weaponID, power));
         emit RaiderJoined(msg.sender, characterID, weaponID, power);
@@ -50,27 +45,6 @@ contract RaidBasic is Initializable, Raid {
     function completeRaid(uint256 seed) public override restricted {
         require(completed == false, "Raid already completed, run reset first");
         completed = true;
-
-        // TODO revisit rewards
-        for(uint i = 0; i < raiders.length; i++) {
-            emit XpReward(address(raiders[i].owner), raiders[i].charID, 96);
-            characters.gainXp(raiders[i].charID, 96);
-        }
-        /*for(uint i = 0; i < raiders.length; i++) {
-            Raider memory r = raiders[i];
-
-            int128 powerPercentage = uint256(r.power).divu(totalPower);
-            uint256 payout = powerPercentage.mulu(bounty);
-            game.payPlayerConverted(address(r.owner), payout);
-            emit SkillWinner(address(r.owner), payout);
-        }*/
-
-        for(uint i = 0; i < weaponDrops.length; i++) {
-            Raider memory r = raiders[RandomUtil.randomSeededMinMax(0, raiders.length-1, RandomUtil.combineSeeds(seed,i))];
-            game.approveContractWeaponFor(weaponDrops[i], address(this));
-            weapons.safeTransferFrom(address(game), address(r.owner), weaponDrops[i]);
-            emit WeaponWinner(address(r.owner), weaponDrops[i]);
-        }
 
         emit RaidCompleted();
     }
@@ -87,23 +61,6 @@ contract RaidBasic is Initializable, Raid {
 
     function getTotalPower() public view returns(uint256) {
         return totalPower;
-    }
-
-    function addRewardWeapon(uint256 id) public restricted {
-        require(weapons.ownerOf(id) == address(game), "Can only add weapons that belong to the main game contract");
-        weaponDrops.push(id);
-    }
-
-    function mintRewardWeapon(uint256 stars, uint256 seed) public restricted {
-        uint256 tokenId = weapons.mintWeaponWithStars(address(game), stars, seed, 100);
-        addRewardWeapon(tokenId);
-    }
-
-    function removeRewardWeapon(uint256 index) public restricted {
-        require(index < weaponDrops.length, "Index out of bounds");
-
-        weaponDrops[index] = weaponDrops[weaponDrops.length - 1];
-        weaponDrops.pop();
     }
 
     function getWeaponDrops() public view returns(uint256[] memory) {


### PR DESCRIPTION
The new payout formula requires some 600k gas added to the deploy size. It's too big, since the limit is around 6.5mil and we're already at 6.4
This PR cuts out a bunch of things to make enough room.

Most notably, the getMyCharacters() and getMyWeapons() functions are removed, which freed up like 226k alone.
This PR is waiting on issue #733 to be addressed (as the frontend was using these functions, but they can be handled in another way, by interacting with the NFT contracts directly)

EDIT: i also cut out a bunch of crap from the old raid files to avoid compilation errors from changing other contracts