### PR TITLE
After land sale UI enhancements

### DIFF
--- a/frontend/src/components/smart/NftList.vue
+++ b/frontend/src/components/smart/NftList.vue
@@ -97,8 +97,8 @@
     </div>
 
     <b-modal class="map-modal" title="Choose zone" ref="map-modal" size="xl" hide-footer
-             @hide="selectedZone = undefined; selectedTier = undefined">
-      <div class="w-100" style="padding-bottom: 100%;">
+             @hide="clearMapSelections()">
+      <div class="w-100 padding-bottom-100">
         <div class="map-grid">
           <div class="zone" v-for="zoneId in zonesIds" :key="zoneId" @click="showZoneModal(zoneId)">
             <span>{{zonesPopulation[zoneId]}}/{{maxZonePopulation.toLocaleString()}}</span>
@@ -108,8 +108,8 @@
     </b-modal>
 
     <b-modal class="map-modal" title="Choose zone" ref="t2-claim-map-modal" size="xl" hide-footer
-             @hide="selectedZone = undefined; selectedTier = undefined">
-      <div class="w-100" style="padding-bottom: 100%;">
+             @hide="clearMapSelections()">
+      <div class="w-100 padding-bottom-100">
         <div class="map-grid">
           <div class="zone" :class="[playerReservedT2Zones.includes(zoneId) ? 'available' : null ]"
                v-for="zoneId in zonesIds" :key="zoneId"
@@ -122,8 +122,8 @@
     </b-modal>
 
     <b-modal class="map-modal" title="Choose zone" ref="t3-claim-map-modal" size="xl" hide-footer
-             @hide="selectedZone = undefined; selectedTier = undefined">
-      <div class="w-100" style="padding-bottom: 100%;">
+             @hide="clearMapSelections()">
+      <div class="w-100 padding-bottom-100">
         <div class="map-grid">
           <div class="zone" :class="[playerReservedT3Zones.includes(zoneId) ? 'available' : null ]"
                v-for="zoneId in zonesIds" :key="zoneId"
@@ -136,7 +136,7 @@
 
     <b-modal ref="zone-modal" title="Choose chunk" size="lg"
              @hide="selectedChunk = undefined" :hide-footer="!selectedTier">
-      <div class="w-100" style="padding-bottom: 100%;">
+      <div class="w-100 padding-bottom-100">
         <div v-if="selectedZone !== undefined" class="zone-grid"
              :style="{ backgroundImage: `url(${require(`@/assets/map-pieces/${selectedZone}.png`)})` }">
           <div class="chunk" :class="[reservedChunks.includes(chunkId.toString()) || takenT3Chunks.includes(chunkId.toString()) ? 'reserved' : null ]"
@@ -157,7 +157,7 @@
 
     <b-modal ref="t2-claim-zone-modal" title="Choose chunk" size="lg"
              @hide="selectedChunk = undefined">
-      <div class="w-100" style="padding-bottom: 100%;">
+      <div class="w-100 padding-bottom-100">
         <div v-if="selectedZone !== undefined" class="zone-grid"
              :style="{ backgroundImage: `url(${require(`@/assets/map-pieces/${selectedZone}.png`)})` }">
           <div class="chunk" :class="[playerReservedT2Chunks.includes(chunkId.toString()) ? 'available' : null ]"
@@ -178,7 +178,7 @@
 
     <b-modal ref="t3-claim-zone-modal" title="Choose chunk" size="lg"
              @hide="selectedChunk = undefined">
-      <div class="w-100" style="padding-bottom: 100%;">
+      <div class="w-100 padding-bottom-100">
         <div v-if="selectedZone !== undefined" class="zone-grid"
              :style="{ backgroundImage: `url(${require(`@/assets/map-pieces/${selectedZone}.png`)})` }">
           <div class="chunk" :class="[playerReservedT3Chunks.includes(chunkId.toString()) ? 'available' : null ]"
@@ -795,6 +795,11 @@ export default Vue.extend({
       this.selectedChunkAvailable = true;
     },
 
+    clearMapSelections() {
+      this.selectedZone = undefined;
+      this.selectedTier = undefined;
+    },
+
     calculateChunksIds(zoneId: number) {
       const chunksIds = [] as number[];
       for (let i = 0; i < 10; i++) {
@@ -1220,6 +1225,10 @@ export default Vue.extend({
 .map-modal {
   max-width: 100%;
   margin: 0.5rem;
+}
+
+.padding-bottom-100 {
+  padding-bottom: 100%;
 }
 
 .map-grid,


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?
![image](https://user-images.githubusercontent.com/34208222/139073207-78b86631-62a5-446b-86c7-407a0adb426c.png)
![image](https://user-images.githubusercontent.com/34208222/139073238-a8fdae1f-2858-479c-b0e0-66862a67be42.png)
![image](https://user-images.githubusercontent.com/34208222/139073310-5c5376b2-3059-4768-b0c8-10ec741e8dac.png)


### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Stop showing ChunkId for Tier 1 Lands bought from the market (does not apply to reserved T1s from resellers, as they already have ids). Also, created a button to show the map with population (works similar to buy/claim map, except there's no footer with the button on zone modal), so that people can browse the map even after land purchase/claim.