### PR TITLE
Allow Options menu to be rendered regardless of state

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -93,6 +93,7 @@ export default {
     hideWalletWarning: false,
     isConnecting: false,
     recruitCost: '',
+    isOptions: false,
   }),
 
   computed: {
@@ -100,7 +101,7 @@ export default {
     ...mapGetters(['contracts', 'ownCharacters', 'getExchangeUrl', 'availableStakeTypes', 'hasStakedBalance']),
 
     canShowApp() {
-      return this.contracts !== null && !_.isEmpty(this.contracts) && !this.showNetworkError;
+      return (this.contracts !== null && !_.isEmpty(this.contracts) && !this.showNetworkError) || (this.isOptions);
     },
 
     showMetamaskWarning() {
@@ -122,6 +123,10 @@ export default {
     },
     $route(to) {
       // react to route changes
+      if(to.path === '/options') {
+        return this.isOptions = true;
+      } else this.isOptions = false;
+
       window.gtag('event', 'page_view', {
         page_title: to.name,
         page_location: to.fullPath,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/60218956/139276211-f9daee04-119a-43e0-920a-f65ad6a0b36e.png)

![image](https://user-images.githubusercontent.com/60218956/139276266-906df91d-a0ac-410f-960b-8b00cbeb4896.png)


#801 


### PR Description
I've changed Options to be able to be rendered no matter the state of the user to allow them to change settings and access the hide wallet warning when the user is prompted to do so. 