### PR TITLE
840 combat modal

### DIFF
--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1689,6 +1689,16 @@ export function createStore(web3: Web3) {
         return await CryptoBlades.methods.getTokenGainForFight(power).call(defaultCallOptions(state));
       },
 
+      async fetchAllowanceTimestamp({ state }) {
+        const { CryptoBlades } = state.contracts();
+        if(!CryptoBlades) return;
+        return await CryptoBlades.methods.vars(6).call(defaultCallOptions(state));
+      },
+      async fetchHourlyAllowance({ state }) {
+        const { CryptoBlades } = state.contracts();
+        if(!CryptoBlades) return;
+        return await CryptoBlades.methods.vars(18).call(defaultCallOptions(state));
+      },
       async fetchRemainingTokenClaimAmountPreTax({ state }) {
         if(!_.isFunction(state.contracts)) return;
         const { CryptoBlades } = state.contracts();

--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -125,7 +125,14 @@
 
       <div></div>
     </div>
-
+    <b-modal class="centered-modal" ref="no-skill-warning-modal" @ok="fightTarget(targetToFight,targetToFightIndex)">
+      <template #modal-title>
+        <b-icon icon="exclamation-circle" variant="danger"/> WARNING
+      </template>
+      <span>
+        You will not gain any SKILL from this fight, but you will still earn <b> XP </b>!
+      </span>
+    </b-modal>
     <div class="blank-slate" v-if="ownWeapons.length === 0 || ownCharacters.length === 0">
       <div v-if="ownWeapons.length === 0">{{$t('combat.noWeapons')}}</div>
 
@@ -163,6 +170,8 @@ export default {
       fightMultiplier: Number(localStorage.getItem('fightMultiplier')),
       staminaPerFight: 40,
       targetExpectedPayouts: new Array(4),
+      targetToFight: null,
+      targetToFightIndex: null,
     };
   },
 
@@ -284,7 +293,19 @@ export default {
       if ((enemyElement + 1) % 4 === playerElement) return -1;
       return 0;
     },
+
     async onClickEncounter(targetToFight, targetIndex) {
+      if(this.targetExpectedPayouts[targetIndex] === '0'){
+        this.$refs['no-skill-warning-modal'].show();
+        this.targetToFight = targetToFight;
+        this.targetToFightIndex = targetIndex;
+      }
+      else{
+        this.fightTarget(targetToFight, targetIndex);
+      }
+    },
+
+    async fightTarget(targetToFight, targetIndex){
       if (this.selectedWeaponId === null || this.currentCharacterId === null) {
         return;
       }

--- a/frontend/src/views/Combat.vue
+++ b/frontend/src/views/Combat.vue
@@ -132,7 +132,7 @@
       <span>
         You will not gain any SKILL from this fight, but you will still earn <b> XP </b>! <br>
         Rewards will be filled in <b> {{minutesToNextAllowance}} </b> min. <br>
-        There were <b> {{lastAllowanceSkill}} </b> distributed during the last allowance.
+        There were up to <b> {{lastAllowanceSkill}} </b> distributed during the last allowance.
       </span>
     </b-modal>
     <div class="blank-slate" v-if="ownWeapons.length === 0 || ownCharacters.length === 0">


### PR DESCRIPTION
### All Submissions

![image](https://user-images.githubusercontent.com/5601589/142837824-ab88c75f-d089-4546-bdff-38c965e67249.png)


### New Feature Submissions

- last subtask of issue #840 

### Notes

- last subtask as requested by MrBaptista with the extra info he requested (Show time of allowance and amount distributed)

### PR Description

- Added modal that pops up when Skill reward will be 0 when fighting the target
- Modal shows time and amount of allowance