### PR TITLE
canAffordBridge should also consider skillRewards

### DIFF
--- a/frontend/src/views/Bridge.vue
+++ b/frontend/src/views/Bridge.vue
@@ -420,7 +420,9 @@ export default Vue.extend({
     canAffordBridge(){
       const cost = toBN(this.bridgeFee);
       const balance = toBN(this.skillBalance);
-      return balance.isGreaterThanOrEqualTo(cost);
+      const skillRewards = toBN(this.skillRewards);
+      const totalBalance = balance.plus(skillRewards);
+      return totalBalance.isGreaterThanOrEqualTo(cost);
     },
   },
   created(){


### PR DESCRIPTION
'request transfer' btn was disabled when user had enough skillRewards but not >0.1 Wallet Skill.
Now it's taking skillRewards into account as well.