### PR TITLE
formula upgrade + front-end tweaks

### DIFF
--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -114,6 +114,10 @@ contract Treasury is Initializable, AccessControlUpgradeable {
         return amountWithMultiplier;
     }
 
+    function getProjectDistributionTime(uint256 projectId) public view returns(uint256) {
+        return projectDistributionTime[projectId];
+    }
+
     // Mutative
 
     function addPartnerProject(

--- a/frontend/partners.json
+++ b/frontend/partners.json
@@ -14,7 +14,8 @@
     },
     "ProjectOasis": {
       "logo": "oasis.png",
-      "details": "The OASIS Metaverse welcomes all nature-loving blockchain gamers to create, own, play, earn and interact with like-minded natives in its virtual world of lush greeneries and natural beauty."
+      "details": "The OASIS Metaverse welcomes all nature-loving blockchain gamers to create, own, play, earn and interact with like-minded natives in its virtual world of lush greeneries and natural beauty.",
+      "website": "https://projectoasis.io/"
     }
   }
 }

--- a/frontend/src/components/PartneredProject.vue
+++ b/frontend/src/components/PartneredProject.vue
@@ -6,21 +6,22 @@
         <h4 class="d-flex align-items-center partner-name">{{name}}</h4>
         <div class="d-flex">
           <h6>Token: {{tokenSymbol}}</h6>
-          <a @click="addTokenToMetamask" class="ml-1 a-button">(Add)</a>
+          <a @click="addTokenToMetamask" class="ml-1 a-button">({{$t('PartneredProject.add')}})</a>
         </div>
         <span class="multiplier-text">{{skillToPartnerRatio}} SKILL/{{tokenSymbol}}</span>
-        <span class="multiplier-text">Multiplier: x{{multiplier}}</span>
+        <span class="multiplier-text">{{$t('PartneredProject.multiplier')}}: x{{multiplier}}</span>
+        <span class="multiplier-text">{{$t('PartneredProject.distribution')}}: {{distributionTime}} {{$t('PartneredProject.days')}}</span>
       </div>
     </div>
     <div class="mt-1 progress w-90 justify-items-center">
       <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
         :style="[{'width': progressBarWidth, 'background-color': '#9e8a57'}]"/>
     </div>
-    <h6 class="mt-1 text-center">Claimed {{tokensClaimed}} / {{tokenSupply}}</h6>
+    <h6 class="mt-1 text-center">{{$t('PartneredProject.claimed')}} {{tokensClaimed}} / {{tokenSupply}}</h6>
     <div class="d-flex flex-column align-items-center w-100">
       <b-card no-body class="collapse-style" v-bind:class="detailsOpened ? 'on-top' : ''">
         <b-card-header class="d-flex flex-column align-items-center w-100 mt-1 p-0" v-b-toggle="'collapse-' + id" @click="toggleDetails()">
-          <h6 class="when-open">Less...</h6><h6 class="when-closed">More...</h6>
+          <h6 class="when-open">{{$t('PartneredProject.less')}}...</h6><h6 class="when-closed">{{$t('PartneredProject.more')}}...</h6>
         </b-card-header>
         <b-collapse :id="'collapse-' + id">
           <b-card-body>
@@ -52,6 +53,7 @@ export interface PartnersInfo {
 interface Data {
   images: any;
   multiplier: string;
+  distributionTime: string;
   tokensClaimed: string;
   skillToPartnerRatio: string;
   updateInterval: ReturnType<typeof setInterval> | null;
@@ -94,6 +96,7 @@ export default Vue.extend({
     return {
       images: require.context('../assets/partners/', false, /\.png$/),
       multiplier: '1',
+      distributionTime: '0',
       tokensClaimed: '0',
       skillToPartnerRatio: '0',
       updateInterval: null,
@@ -130,7 +133,7 @@ export default Vue.extend({
   },
 
   methods: {
-    ...mapActions(['getPartnerProjectMultiplier', 'getPartnerProjectClaimedAmount', 'getSkillToPartnerRatio']),
+    ...mapActions(['getPartnerProjectMultiplier', 'getPartnerProjectClaimedAmount', 'getSkillToPartnerRatio', 'getPartnerProjectDistributionTime']),
     imgPath(img: string): string {
       return this.images('./' + img);
     },
@@ -138,6 +141,9 @@ export default Vue.extend({
     async update(): Promise<void> {
       const currentMultiplier = await this.getPartnerProjectMultiplier(this.id);
       this.multiplier = toBN(currentMultiplier).div(toBN(10).pow(18)).toFixed(4);
+
+      const distributionTime = await this.getPartnerProjectDistributionTime(this.id);
+      this.distributionTime = distributionTime;
 
       const currentClaimedTokens = await this.getPartnerProjectClaimedAmount(this.id);
       this.tokensClaimed = toBN(currentClaimedTokens).div(toBN(10).pow(18)).toFixed(2);
@@ -176,7 +182,7 @@ export default Vue.extend({
 <style scoped>
 .partner-div {
   width: 280px;
-  height: 215px;
+  height: 230px;
   border: 2px solid #9e8a57;
   border-radius: 10px;
   padding: 5px;

--- a/frontend/src/components/PartneredProject.vue
+++ b/frontend/src/components/PartneredProject.vue
@@ -6,7 +6,7 @@
         <h4 class="d-flex align-items-center partner-name">{{name}}</h4>
         <div class="d-flex">
           <h6>Token: {{tokenSymbol}}</h6>
-          <a @click="addTokenToMetamask" class="ml-1 add-token-button">(Add)</a>
+          <a @click="addTokenToMetamask" class="ml-1 a-button">(Add)</a>
         </div>
         <span class="multiplier-text">{{skillToPartnerRatio}} SKILL/{{tokenSymbol}}</span>
         <span class="multiplier-text">Multiplier: x{{multiplier}}</span>
@@ -24,7 +24,14 @@
         </b-card-header>
         <b-collapse :id="'collapse-' + id">
           <b-card-body>
-            <b-card-text>{{partnerDetails}}</b-card-text>
+            <b-card-text>
+              <div>
+                {{partnerDetails}}
+              </div>
+              <div>
+                <a class="a-button" @click="openPartnerWebsite">{{partnerWebsite}}</a>
+              </div>
+            </b-card-text>
           </b-card-body>
         </b-collapse>
       </b-card>
@@ -104,6 +111,10 @@ export default Vue.extend({
       return (partnersInfo as PartnersInfo).partners[this.name].details;
     },
 
+    partnerWebsite(): string {
+      return (partnersInfo as PartnersInfo).partners[this.name].website;
+    },
+
     partnerLogoPath(): string {
       const fileName = (partnersInfo as PartnersInfo).partners[this.name].logo;
       return this.imgPath(fileName);
@@ -126,7 +137,7 @@ export default Vue.extend({
 
     async update(): Promise<void> {
       const currentMultiplier = await this.getPartnerProjectMultiplier(this.id);
-      this.multiplier = toBN(currentMultiplier).div(toBN(10).pow(18)).toFixed(3);
+      this.multiplier = toBN(currentMultiplier).div(toBN(10).pow(18)).toFixed(4);
 
       const currentClaimedTokens = await this.getPartnerProjectClaimedAmount(this.id);
       this.tokensClaimed = toBN(currentClaimedTokens).div(toBN(10).pow(18)).toFixed(2);
@@ -141,6 +152,10 @@ export default Vue.extend({
 
     async addTokenToMetamask() {
       await addTokenToMetamask(this.tokenAddress, this.tokenSymbol);
+    },
+
+    openPartnerWebsite() {
+      window.open(this.partnerWebsite, '_blank');
     }
   },
 
@@ -191,7 +206,8 @@ export default Vue.extend({
 .on-top {
   z-index: 10;
 }
-.add-token-button {
+.a-button {
   line-height: 1.2;
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/components/smart/ClaimRewardsBar.vue
+++ b/frontend/src/components/smart/ClaimRewardsBar.vue
@@ -104,13 +104,13 @@
         </div>
         <div v-if="selectedPartneredProject" class="d-flex mt-2">
           <div class="d-flex justify-content-center align-items-center">
-            <h6 class="claim-input-text">Skill Amount:</h6>
+            <h6 class="claim-input-text">{{$t('ClaimRewardsBar.skillAmount')}}:</h6>
             <b-form-input v-bind:class="!isSkillAmountValid ? 'invalid-amount' : ''"
-              type="number" step="0.0001" :max="skillRewardNumber" v-model="skillAmount" class="claim-input" />
+              type="number" min="0" step="0.0001" :max="skillRewardNumber" v-model="skillAmount" class="claim-input" />
             <a class="" @click="setMaxSkillAmount">(Max)</a>
           </div>
           <div class="d-flex justify-content-center align-items-center">
-            <h6 class="claim-input-text">Slippage (%):</h6>
+            <h6 class="claim-input-text">{{$t('ClaimRewardsBar.slippage')}} (%):</h6>
             <b-form-input type="number" step="0.5" v-model="slippage" class="claim-input" />
           </div>
         </div>
@@ -120,7 +120,7 @@
           :tokenPrice="selectedPartneredProject.tokenPrice" :logoFileName="getLogoFile(selectedPartneredProject.name)"
           :tokenAddress="selectedPartneredProject.tokenAddress"/>
         <div class="mt-3" v-if="selectedPartneredProject && !canClaimSelectedProject">
-          <h5>This partner tokens have been claimed already.</h5>
+          <h5>{{$t('ClaimRewardsBar.partnerTokenClaimed')}}</h5>
         </div>
         <div class="mt-3" v-if="!selectedPartneredProject">
           <h5>{{withdrawalInfoText}}</h5>

--- a/frontend/src/components/smart/ClaimRewardsBar.vue
+++ b/frontend/src/components/smart/ClaimRewardsBar.vue
@@ -111,7 +111,7 @@
           </div>
           <div class="d-flex justify-content-center align-items-center">
             <h6 class="claim-input-text">{{$t('ClaimRewardsBar.slippage')}} (%):</h6>
-            <b-form-input type="number" step="0.5" v-model="slippage" class="claim-input" />
+            <b-form-input type="number" max="100" step="0.5" v-model="slippage" class="claim-input" />
           </div>
         </div>
         <partnered-project v-if="selectedPartneredProject"
@@ -353,8 +353,8 @@ export default Vue.extend({
           {
             id: +this.payoutCurrencyId,
             skillAmount: toBN(this.skillAmount).multipliedBy(toBN(10).pow(18)).toString(),
-            currentMultiplier: toBN(currentMultiplier).multipliedBy(toBN(10).pow(18)).toString(),
-            slippage: this.slippage.toString()
+            currentMultiplier: toBN(currentMultiplier).toString(),
+            slippage: toBN(this.slippage).multipliedBy(toBN(10).pow(16)).toString()
           }
         );
       }
@@ -383,7 +383,7 @@ export default Vue.extend({
       if(stage === ClaimStage.Summary) {
         await this.fetchPartnerProjects();
         this.skillAmount = this.skillRewardNumber;
-        this.slippage = +this.defaultSlippage;
+        this.slippage = +toBN(this.defaultSlippage).dividedBy(toBN(10).pow(16));
         (this.$refs['claim-summary-modal'] as any).show();
       }
       await this.getRemainingTokenClaimAmountPreTax();

--- a/frontend/src/components/smart/ClaimRewardsBar.vue
+++ b/frontend/src/components/smart/ClaimRewardsBar.vue
@@ -8,9 +8,7 @@
 
       <b-nav-item
         class="ml-3 bar"
-        :disabled="!canClaimTokens"
-        @click="claimSkill(ClaimStage.Summary)"
-        v-tooltip.bottom="!canClaimTokens ? withdrawalInfoText : ''"><!-- moved gtag-link below b-nav-item -->
+        @click="claimSkill(ClaimStage.Summary)"><!-- moved gtag-link below b-nav-item -->
         <span class="gtag-link-others" tagname="claim_skill" v-tooltip.bottom="$t('ClaimRewardsBar.clickDetails')">
           <strong>SKILL</strong> {{ formattedSkillReward }}
         </span>
@@ -34,7 +32,6 @@
         </template>
 
         <b-dropdown-item
-          :disabled="!canClaimTokens"
           @click="claimSkill(ClaimStage.Summary)" class="rewards-info gtag-link-others" tagname="claim_skill"
            v-tooltip.bottom="$t('ClaimRewardsBar.clickDetails')">
             SKILL
@@ -94,7 +91,7 @@
     </b-modal>
     <b-modal class="centered-modal" ref="claim-summary-modal" :title="$t('ClaimRewardsBar.claimRewards')"
       :ok-title="$t('ClaimRewardsBar.claim')" @ok="onClaimTokens()"
-      :ok-disabled="selectedPartneredProject && !canClaimSelectedProject">
+      :ok-disabled="(selectedPartneredProject && !canClaimSelectedProject) || (!selectedPartneredProject && !canClaimTokens)">
       <div class="d-flex flex-column align-items-center">
         <div class="d-flex flex-row w-100 align-items-baseline">
           <h5>{{$t('ClaimRewardsBar.payoutCurrency')}}:</h5>

--- a/frontend/src/interfaces/State.ts
+++ b/frontend/src/interfaces/State.ts
@@ -175,6 +175,7 @@ export interface IState {
 
   partnerProjects: Record<number, IPartnerProject>;
   payoutCurrencyId: string;
+  defaultSlippage: string;
 
   itemPrices: IItemPrices;
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -20,7 +20,10 @@
     "clickDetails" : "Click to claim and see the details",
     "claim":"Claim",
     "claimRewards": "Claim Rewards",
-    "payoutCurrency": "Payout Currency"
+    "payoutCurrency": "Payout Currency",
+    "partnerTokenClaimed": "This partner tokens have been claimed already.",
+    "slippage": "Slippage",
+    "skillAmount": "Skill Amount"
   },
   "CharacterDisplay":{
     "loading":"Loading...",
@@ -698,5 +701,19 @@
     "lightning" : "Lightning",
     "water" : "Water"
   },
-  "copyLink": "Copy link"
+  "copyLink": "Copy link",
+  "Treasury": {
+    "formulaDetailsTitle": "Claiming Formula Details",
+    "partneredProjects": "Partnered Projects",
+    "payoutCurrency": "Payout Currency"
+  },
+  "PartneredProject": {
+    "multiplier": "Multiplier",
+    "distribution": "Distribution",
+    "days": "days",
+    "add": "Add",
+    "claimed": "Claimed",
+    "more": "More",
+    "less": "Less"
+  }
 }

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -3486,6 +3486,15 @@ export function createStore(web3: Web3) {
         return multiplier;
       },
 
+      async getPartnerProjectDistributionTime({ state }, id) {
+        const { Treasury } = state.contracts();
+        if(!Treasury || !state.defaultAccount) return;
+
+        const distributionTime = await Treasury.methods.getProjectDistributionTime(id).call(defaultCallOptions(state));
+
+        return distributionTime;
+      },
+
       async getPartnerProjectClaimedAmount({ state }, id) {
         const { Treasury } = state.contracts();
         if(!Treasury || !state.defaultAccount) return;

--- a/frontend/src/views/Treasury.vue
+++ b/frontend/src/views/Treasury.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="d-flex align-items-center flex-column">
     <div class="d-flex flex-column align-items-center w-50">
-      <h3 class="mt-2"> Partnered Projects </h3>
+      <div class="d-flex">
+        <h3 class="mt-2"> {{$t('Treasury.partneredProjects')}} </h3>
+        <b-icon-question-circle class="h3 mt-2 ml-3 pointer" @click="openFormulaDetails" v-tooltip="'Click for details'"/>
+      </div>
       <img src="../assets/divider4.png" class="expander-divider">
     </div>
     <div class="d-flex w-100 align-items-baseline mt-3 pl-5">
-      <h5>Payout Currency:</h5>
+      <h5>{{$t('Treasury.payoutCurrency')}}:</h5>
       <b-form-select class="w-25 ml-1" size="sm" :value="payoutCurrencyId" @change="updatePayoutCurrencyId($event)">
         <b-form-select-option :value="-1">SKILL</b-form-select-option>
         <b-form-select-option v-for="p in supportedProjects" :key="p.id" :value="p.id">{{p.tokenSymbol}} ({{p.name}})</b-form-select-option>
@@ -16,6 +19,19 @@
         :tokenSupply="p.tokenSupply" :tokenPrice="p.tokenPrice" :logoFileName="getLogoFile(p.name)"
         :tokenAddress="p.tokenAddress"/>
     </div>
+    <b-modal ok-only class="centered-modal" ref="formula-details-modal" :title="$t('Treasury.formulaDetailsTitle')">
+      <span>
+        Payout formula is designed to guarantee that rewards will be distributed over assumed distribution time.<br><br>
+        Multiplier is evenly increasing throughout a day at a speed of 100% per day.<br><br>
+        Every claim lowers the multiplier based on the amount of partner tokens claimed and the desired distribution time.<br><br>
+        That means multiplier can go below x1 resulting in claiming less partner tokens than the claimed SKILL tokens are worth.<br><br>
+        E.g. The supply of partner tokens is 100 tokens. The distribution time is 10 days.<br>
+        In this scenario each partner token (1) claimed will lower the multiplier by 1 / (100 / 10) = 0.1 = 10%<br><br>
+        You can adjust the amount of SKILL that you want to claim as well as slippage.<br><br>
+        Slippage will protect you from claiming less tokens than you intended -
+        if some else claims right before you, lowering the multiplier enough, your transaction will fail instead of claiming less tokens.
+      </span>
+    </b-modal>
   </div>
 </template>
 
@@ -90,6 +106,10 @@ export default Vue.extend({
     getLogoFile(projectName: string): string {
       return `${projectName.toLowerCase()}.png`;
     },
+
+    openFormulaDetails(): void {
+      (this.$refs['formula-details-modal'] as any).show();
+    }
   },
 
   async mounted() {

--- a/migrations/108_multifarm_formula.js
+++ b/migrations/108_multifarm_formula.js
@@ -6,5 +6,6 @@ module.exports = async function (deployer, network, accounts) {
     const treasury = await upgradeProxy(Treasury.address, Treasury, { deployer });
     // 1/86400 = 0.00001157407 per second = 1 (100%) per day
     await treasury.setMultiplierUnit('86400');
-    await treasury.setDefaultSlippage('5');
+    // slippage 5%
+    await treasury.setDefaultSlippage('50000000000000000');
 };

--- a/migrations/108_multifarm_formula.js
+++ b/migrations/108_multifarm_formula.js
@@ -6,4 +6,5 @@ module.exports = async function (deployer, network, accounts) {
     const treasury = await upgradeProxy(Treasury.address, Treasury, { deployer });
     // 1/86400 = 0.00001157407 per second = 1 (100%) per day
     await treasury.setMultiplierUnit('86400');
+    await treasury.setDefaultSlippage('5');
 };

--- a/migrations/108_multifarm_formula.js
+++ b/migrations/108_multifarm_formula.js
@@ -1,0 +1,9 @@
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+
+const Treasury = artifacts.require("Treasury");
+
+module.exports = async function (deployer, network, accounts) {
+    const treasury = await upgradeProxy(Treasury.address, Treasury, { deployer });
+    // 1/86400 = 0.00001157407 per second = 1 (100%) per day
+    await treasury.setMultiplierUnit('86400');
+};


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?
![image](https://user-images.githubusercontent.com/9114200/144475455-d5e0d891-eacf-4db9-8dc3-c918b5da52e3.png)
![image](https://user-images.githubusercontent.com/9114200/144475478-32c99a98-eb7d-4b46-b8cb-af81df5f0ca1.png)
![image](https://user-images.githubusercontent.com/9114200/144475502-e37f2441-d09e-47b0-af0c-f72de8b6c10a.png)
![image](https://user-images.githubusercontent.com/9114200/144475537-3789ba46-2225-4211-bfa0-9e1e0ef0ab08.png)

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Claim formula upgrade:
- Multiplier is being increase by 100% daily based on block.timestamp, that means consistent increase with each second that passes
- claiming action decreases the multiplier by `amount of partner tokens to claim`/(`total supply`/`distribution time`)
- distribution time is adjustable to speed up / slow down distribution
- added input to choose skill amount to claim and slippage
Note: I did not test the slippage, will need testnet for that.

Front-end tweaks:
- added website to partner project info
- fixed claim reward bar being disabled after claiming daily skill allowance (now the claim modal shows up every time and claiming is handled there)