### PR TITLE
+ transfer option in dropdown

### DIFF
--- a/frontend/src/components/NftOptionsDropdown.vue
+++ b/frontend/src/components/NftOptionsDropdown.vue
@@ -6,13 +6,48 @@
       @click="nftType ? option.handler(nftId, nftType) : option.handler(nftId)">
         {{option.name}} <span v-if="!option.noAmount">({{option.amount}} {{$t('nftOptionsDropdown.left')}})</span>
       </b-dropdown-item>
+      <b-dropdown-item @click="resultMsg = ''; $refs['character-transfer-modal'].show()">
+        Transfer
+      </b-dropdown-item>
     </b-dropdown>
+
+    <b-modal
+      class="centered-modal"
+      ref="character-transfer-modal"
+      ok-title="Transfer!"
+      @ok="transfer"
+      :ok-disabled="!isValidAddress || receiverAddress === ''  || isSending"
+      :cancel-disabled="isSending"
+      >
+      <template #modal-title>
+        Send your {{nftType}} to another account
+      </template>
+      <b-form-input placeholder="Receiver Address" v-model="receiverAddress"/>
+      <div class="transferResultContainer">
+        <div class="loader" v-if="isSending">
+          <i class="fas fa-spinner fa-spin"></i>
+            Loading...
+        </div>
+        <span class="resultMsg text-center"> {{(!isValidAddress && receiverAddress !== '') ? 'Invalid address' : ''}} </span>
+        <span class="resultMsg text-center"> {{resultMsg}} </span>
+      </div>
+    </b-modal>
+
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import { PropType } from 'vue/types/options';
+import { mapActions } from 'vuex';
+
+interface StoreMappedActions {
+  transferNFT(payload: {
+    nftId: number;
+    receiverAddress: string;
+    nftType: string;
+  }): Promise<void>;
+}
 
 export interface NftOption {
   name: string;
@@ -39,10 +74,39 @@ export default Vue.extend({
       default: '',
     }
   },
-
+  data: () => ({
+    receiverAddress: '' as string,
+    isSending: false as boolean,
+    resultMsg: '' as string,
+    successfullTransfer: false as boolean,
+  }),
+  computed: {
+    isValidAddress() {
+      return /^0x[a-fA-F0-9]{40}$/.test(this.receiverAddress);
+    },
+  },
   methods: {
+    ...(mapActions([
+      'transferNFT',
+    ]) as StoreMappedActions),
     isDisabled(option: NftOption): boolean {
       return !option.hasDefaultOption && +option.amount === 0;
+    },
+    async transfer(bvModalEvt: Event) {
+      bvModalEvt.preventDefault();
+      this.isSending = true;
+      try {
+        await this.transferNFT({
+          nftId: this.nftId,
+          receiverAddress: this.receiverAddress,
+          nftType: this.nftType
+        });
+      }
+      catch(e: any) {
+        if(e.code as number === 4001) this.resultMsg = 'You cancelled the transaction.';
+        else this.resultMsg = 'Error while transferring your ' + this.nftType + ' to ' + this.receiverAddress;
+      }
+      this.isSending = false;
     }
   }
 });
@@ -70,4 +134,26 @@ export default Vue.extend({
   border: 0 !important;
   border-radius: 16px !important;
 }
+.transferResultContainer{
+  display:flex;
+  align-items:center;
+  flex-direction: column;
+  margin-top: 20px;
+  overflow: hidden;
+}
+.resultMsg{
+  color: rgb(197, 48, 48);
+  font-size: 1.5rem;
+}
+.success{
+  color: rgb(0, 128, 0);
+}
+.loader{
+  text-align: center;
+  font-size: 1.5em;
+}
 </style>
+
+function dispatch(arg0: string) {
+  throw new Error('Function not implemented.');
+}

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -3780,6 +3780,27 @@ export function createStore(web3: Web3) {
           console.log(err);
         }
       },
+      async transferNFT({ state, dispatch },{nftId, receiverAddress, nftType}: {nftId: number, receiverAddress: string, nftType: string}) {
+        const { Characters, Weapons } = state.contracts();
+        if (!Characters || !Weapons || !state.defaultAccount) return;
+
+        if (nftType === 'character') {
+          await Characters.methods
+            .safeTransferFrom(state.defaultAccount, receiverAddress, nftId)
+            .send({
+              from: state.defaultAccount,
+            });
+          await dispatch('updateCharacterIds');
+        }
+        else if (nftType === 'weapon') {
+          await Weapons.methods
+            .safeTransferFrom(state.defaultAccount, receiverAddress, nftId)
+            .send({
+              from: state.defaultAccount,
+            });
+          await dispatch('updateWeaponIds');
+        }
+      }
     },
   });
 }


### PR DESCRIPTION
### All Submissions

- see #870 

### New Feature Submissions

- #870 

### PR Description

- Added 'Transfer' option in the NftOptionsDropdown component
- Opens a modal that let's you input an address to send to 
- On error an error message is displayed, if successful weapons/chars are updated and the modal closes