### PR TITLE
Fix css order & mobile menu

### DIFF
--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -116,7 +116,6 @@ a.router-link-active {
  .navbar-expand-sm {
     text-align: center;
     margin: 0 auto;
-    display: block;
   }
 }
 
@@ -147,7 +146,6 @@ a.router-link-active {
   .navbar-expand-sm {
     text-align: center;
     margin: 0 auto;
-    display: block;
   }
   .nav-logo{
     margin-right:0 !important;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,10 +1,13 @@
+import BootstrapVue from 'bootstrap-vue';
+import { BootstrapVueIcons } from 'bootstrap-vue';
+import BootstrapVueDialog from 'bootstrap-vue-dialog';
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue/dist/bootstrap-vue.css';
+
 import Vue from 'vue';
 import Vuex from 'vuex';
 import VueRouter from 'vue-router';
 import VTooltip from 'v-tooltip';
-import BootstrapVue from 'bootstrap-vue';
-import { BootstrapVueIcons } from 'bootstrap-vue';
-import BootstrapVueDialog from 'bootstrap-vue-dialog';
 
 import Web3 from 'web3';
 
@@ -13,8 +16,6 @@ import createRouter from './router';
 
 import App from './App.vue';
 
-import 'bootstrap/dist/css/bootstrap.css';
-import 'bootstrap-vue/dist/bootstrap-vue.css';
 import Ads from 'vue-google-adsense';
 
 import {


### PR DESCRIPTION
- Load bootstrap css first, so that it will be overwritte by <style> and <style scoped>
- Frontend should now appear on a local serve like on prod build.
- Also removed display:block from the navbar mobile queries. (it was overwriting the display:flex from bootstrap)

before:
![image](https://user-images.githubusercontent.com/5601589/146398562-49b99563-a0a1-49cf-aadd-be194a9d8194.png)
->
![image](https://user-images.githubusercontent.com/5601589/146398679-c799407b-17d2-43b2-bc35-b3b27155089a.png)
![image](https://user-images.githubusercontent.com/5601589/146398700-2a064113-307c-4e0a-a145-d7ebf9eab94a.png)
