### PR TITLE
resolves #793

### DIFF
--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -1,11 +1,34 @@
 import axios from 'axios';
 import BigNumber from 'bignumber.js';
 import Web3 from 'web3';
+import config from '../../app-config.json';
 
 BigNumber.config({ ROUNDING_MODE: BigNumber.ROUND_DOWN });
 BigNumber.config({ EXPONENTIAL_AT: 100 });
 
 const web3 = new Web3(Web3.givenProvider || process.env.VUE_APP_WEB3_FALLBACK_PROVIDER);
+
+interface Config {
+  environments: Record<string, Chain>;
+}
+
+interface Chain {
+  chains: Record<string, Record<string, any>>;
+}
+
+// executes when network is changed in MetaMask
+(window as any).ethereum.on('chainChanged', (chainIdHex: string) => {
+  const chainId = parseInt(chainIdHex, 16);
+  const env = window.location.href.startsWith('https://test') ? 'test' : 'production';
+  const chains = (config as Config).environments[env].chains;
+
+  for (const [chainName, values] of Object.entries(chains)){
+    if(+values.VUE_APP_NETWORK_ID === chainId){
+      localStorage.setItem('currentChain', chainName);
+    }
+  }
+  window.location.reload();
+});
 
 export const apiUrl = (url: string) => `${process.env.VUE_APP_API_URL || 'https://api.cryptoblades.io'}/${url}`;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7676,7 +7676,7 @@
         "@truffle/contract-sources": "^0.1.12",
         "@truffle/error": "^0.0.14",
         "@truffle/expect": "^0.0.18",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "debug": "^4.3.1"
       }
     },
@@ -22437,7 +22437,7 @@
       "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
       "dev": true,
       "requires": {
-        "colors": "^1.2.1",
+        "colors": "1.4.0",
         "fast-safe-stringify": "^2.0.4",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
@@ -26848,7 +26848,7 @@
       "integrity": "sha512-75mVsggAJRSykWy2qxdGI7osocDWvc3RCMeN93hlvS/FxgdRww12NaXslez+W6gBOrSJKO7W16V0IzuISSfCxg==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2"
+        "colors": "1.4.0"
       }
     },
     "redux-devtools-core": {


### PR DESCRIPTION
- resolves #793  - Automatic chain switch
- Added some lines in common.ts so that an event is triggered when the user changes network from Metamask
- localstorage is then filled with the chain name and the page reloads
- we could now change the 'You can't currently view the app right now. You can try clearing LocalStorage to reset your settings.' error to something else, because it only appears, when the user selects a testnet when on prod or vice versa. It's also shown briefly, after the page reload