### PR TITLE
Move Merchandise to a separate tab, secure it, add tooltip

### DIFF
--- a/frontend/src/components/ViewLinks.vue
+++ b/frontend/src/components/ViewLinks.vue
@@ -2,25 +2,25 @@
   <b-navbar-nav>
 
     <router-link :to="{ name: 'plaza' }" exact class="nav-link"
-    v-if="!featureFlagStakeOnly">
+                 v-if="!featureFlagStakeOnly">
       <li class="nav-item nav-top-links">
         <span class="gtag-link-others" tagname="plaza_screen">{{ $t("viewLink.plaza") }}</span>
       </li>
     </router-link>
 
-    <router-link :to="{ name: 'blacksmith' }" exact class="nav-link"   v-if="!featureFlagStakeOnly">
-      <li class="nav-item nav-top-links" >
+    <router-link :to="{ name: 'blacksmith' }" exact class="nav-link" v-if="!featureFlagStakeOnly">
+      <li class="nav-item nav-top-links">
         <span class="gtag-link-others" tagname="blacksmith_screen">{{ $t("viewLink.blacksmith") }}</span>
       </li>
     </router-link>
 
-    <router-link :to="{ name: 'combat' }" exact class="nav-link"  v-if="!featureFlagStakeOnly">
-      <li class="nav-item nav-top-links" >
+    <router-link :to="{ name: 'combat' }" exact class="nav-link" v-if="!featureFlagStakeOnly">
+      <li class="nav-item nav-top-links">
         <span class="gtag-link-others" tagname="combat_screen">{{ $t("viewLink.combat") }}</span>
       </li>
     </router-link>
 
-    <router-link :to="{ name: 'raid' }" exact class="nav-link"  v-if="!featureFlagStakeOnly && featureFlagRaid">
+    <router-link :to="{ name: 'raid' }" exact class="nav-link" v-if="!featureFlagStakeOnly && featureFlagRaid">
       <li class="nav-item nav-top-links">
         <span class="gtag-link-others" tagname="raid_screen">{{ $t("viewLink.raid") }}</span>
       </li>
@@ -45,8 +45,17 @@
     </router-link>
 
     <router-link :to="{ name: 'treasury' }" exact class="nav-link">
-      <li class="nav-item nav-top-links" >
+      <li class="nav-item nav-top-links">
         <span class="gtag-link-others" tagname="treasury_screen">Treasury</span>
+      </li>
+    </router-link>
+
+    <router-link v-if="featureFlagMerchandise" :to="{ name: 'merchandise' }" exact class="nav-link">
+      <li class="nav-item nav-top-links">
+        <span class="gtag-link-others" tagname="merchandise_screen"
+              :class="supportsMerchandise ? '' : 'disabled'">{{ $t("viewLink.merchandise") }} <hint
+          v-if="!supportsMerchandise" class="hint"
+          :text="$t('viewLink.merchandiseNotSupportedTooltip')"/></span>
       </li>
     </router-link>
 
@@ -54,12 +63,28 @@
 </template>
 
 <script>
-import { market as featureFlagMarket, portal as featureFlagPortal, pvp as featureFlagPvp } from '../feature-flags';
+import {
+  market as featureFlagMarket,
+  merchandise as featureFlagMerchandise,
+  portal as featureFlagPortal,
+  pvp as featureFlagPvp
+} from '../feature-flags';
+import {mapGetters, mapMutations} from 'vuex';
+import Events from '@/events';
+import Vue from 'vue';
+import Hint from '@/components/Hint';
 
-export default {
+export default Vue.extend({
   inject: ['featureFlagStakeOnly', 'featureFlagRaid'],
 
+  data() {
+    return {
+      supportsMerchandise: false
+    };
+  },
+
   computed: {
+    ...mapGetters(['getCurrentChainSupportsMerchandise']),
     featureFlagMarket() {
       return featureFlagMarket;
     },
@@ -68,9 +93,26 @@ export default {
     },
     featureFlagPvp() {
       return featureFlagPvp;
+    },
+    featureFlagMerchandise() {
+      return featureFlagMerchandise;
     }
   },
-};
+
+  mounted() {
+    this.updateCurrentChainSupportsMerchandise();
+    this.supportsMerchandise = this.getCurrentChainSupportsMerchandise;
+    Events.$on('setting:currentChain', () => {
+      this.supportsMerchandise = this.getCurrentChainSupportsMerchandise;
+    });
+  },
+  methods: {
+    ...mapMutations(['updateCurrentChainSupportsMerchandise']),
+  },
+  components: {
+    Hint,
+  },
+});
 </script>
 
 <style scoped>
@@ -79,8 +121,13 @@ a {
 }
 
 .nav-top-links > span {
-  color : #BFA765;
+  color: #BFA765;
   font-size: 1.1em;
   padding: 0px 5px 0px 5px;
+}
+
+.disabled {
+  cursor: not-allowed;
+  color: gray !important;
 }
 </style>

--- a/frontend/src/interfaces/State.ts
+++ b/frontend/src/interfaces/State.ts
@@ -145,6 +145,7 @@ export interface IState {
   maxStamina: number;
   ownedDust: string[];
   cartEntries: CartEntry[];
+  currentChainSupportsMerchandise: boolean;
 
   currentCharacterId: number | null;
   characters: Record<number, ICharacter>;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -7,7 +7,9 @@
     "raid": "Raid",
     "pvp": "PvP",
     "market": "Market",
-    "stake": "Stake"
+    "stake": "Stake",
+    "merchandise": "Merchandise",
+    "merchandiseNotSupportedTooltip": "Currently selected chain does not support Merchandise."
   },
   "ClaimRewardsBar": {
     "rewards": "Rewards",

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -20,8 +20,11 @@ import {
   stakeOnly as featureFlagStakeOnly,
   market as featureFlagMarket,
   portal as featureFlagPortal,
-  pvp as featureFlagPvP
+  pvp as featureFlagPvP,
+  merchandise as featureFlagMerchandise,
 } from './feature-flags';
+import Merchandise from '@/components/smart/Merchandise.vue';
+import {currentChainSupportsMerchandise} from '@/utils/common';
 
 function createRouter() {
   if (featureFlagStakeOnly) {
@@ -68,6 +71,17 @@ function createRouter() {
 
   if(featureFlagPvP){
     router.addRoute({ path: '/pvp', name: 'pvp', component:PvP});
+  }
+
+  const merchandiseRoute = { path: '/merchandise', name: 'merchandise', component:Merchandise,
+    beforeEnter: (to: any, from: any, next: any) => {
+      if (to.name === 'merchandise' && !currentChainSupportsMerchandise()) next(from);
+      else next();
+    }
+  };
+
+  if(featureFlagMerchandise){
+    router.addRoute(merchandiseRoute);
   }
 
   return router;

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -744,7 +744,7 @@ export function createStore(web3: Web3) {
         const currentChain = localStorage.getItem('currentChain') || 'BSC';
         const merchandiseSupportedChains = config.merchandiseSupportedChains;
         if (!currentChain || !merchandiseSupportedChains) {
-          return false;
+          state.currentChainSupportsMerchandise = false;
         }
         state.currentChainSupportsMerchandise = merchandiseSupportedChains.includes(currentChain);
       },

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -43,6 +43,7 @@ import axios from 'axios';
 import {abi as erc20Abi} from '../../build/contracts/IERC20.json';
 import {abi as priceOracleAbi} from '../../build/contracts/IPriceOracle.json';
 import {CartEntry} from '@/components/smart/VariantChoiceModal.vue';
+import config from '../app-config.json';
 
 const transakAPIURL = process.env.VUE_APP_TRANSAK_API_URL || 'https://staging-global.transak.com';
 const transakAPIKey = process.env.VUE_APP_TRANSAK_API_KEY || '90167697-74a7-45f3-89da-c24d32b9606c';
@@ -133,6 +134,7 @@ export function createStore(web3: Web3) {
       currentCharacterId: null,
       ownedDust: [],
       cartEntries: [],
+      currentChainSupportsMerchandise: false,
 
       characters: {},
       garrisonCharacters: {},
@@ -423,6 +425,10 @@ export function createStore(web3: Web3) {
 
       getCartEntries(state) {
         return state.cartEntries;
+      },
+
+      getCurrentChainSupportsMerchandise(state) {
+        return state.currentChainSupportsMerchandise;
       },
 
       ownWeapons(state, getters) {
@@ -732,6 +738,15 @@ export function createStore(web3: Web3) {
 
       clearCartEntries(state: IState) {
         state.cartEntries = [];
+      },
+
+      updateCurrentChainSupportsMerchandise(state: IState) {
+        const currentChain = localStorage.getItem('currentChain') || 'BSC';
+        const merchandiseSupportedChains = config.merchandiseSupportedChains;
+        if (!currentChain || !merchandiseSupportedChains) {
+          return false;
+        }
+        state.currentChainSupportsMerchandise = merchandiseSupportedChains.includes(currentChain);
       },
 
       updateCharacter(state: IState, { characterId, character }) {

--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -91,3 +91,12 @@ export const addTokenToMetamask = async (address: string, symbol: string): Promi
     console.error(error);
   }
 };
+
+export const currentChainSupportsMerchandise = () => {
+  const currentChain = localStorage.getItem('currentChain') || 'BSC';
+  const merchandiseSupportedChains = config.merchandiseSupportedChains;
+  if (!currentChain || !merchandiseSupportedChains) {
+    return false;
+  }
+  return merchandiseSupportedChains.includes(currentChain);
+};

--- a/frontend/src/views/Market.vue
+++ b/frontend/src/views/Market.vue
@@ -681,24 +681,6 @@
           </div>
         </div>
       </b-tab>
-      <b-tab v-if="isMerchandiseEnabled && currentChainSupportsMerchandise()"
-             @click="clearData();browseTabActive = false;skillShopTabActive = false">
-        <template #title>
-          {{$t('market.merchandise.merchandise')}}
-          <hint class="hint" text="You can buy real merchandise in here" />
-        </template>
-
-        <div>
-          <div class="row">
-            <img class="shop-horizontal-divider-top" src="../assets/divider4.png"  alt=""/>
-          </div>
-          <div class="col-sm-12 merchandise-shop-items">
-            <div class="shop-items">
-              <Merchandise />
-            </div>
-          </div>
-        </div>
-      </b-tab>
     </b-tabs>
   </div>
 </template>
@@ -719,7 +701,7 @@ import {Characters, Shields, Weapons} from '../../../build/abi-interfaces';
 import {SkillShopListing} from '@/interfaces/SkillShopListing';
 import BigNumber from 'bignumber.js';
 import {traitNameToNumber} from '@/contract-models';
-import {market_blockchain as useBlockchain, merchandise as merchandiseEnabled} from './../feature-flags';
+import {market_blockchain as useBlockchain} from './../feature-flags';
 import {
   CharacterTransactionHistoryData,
   ICharacterHistory,
@@ -734,8 +716,6 @@ import NftList, {NftIdType} from '@/components/smart/NftList.vue';
 import {getCleanName} from '@/rename-censor';
 import i18n from '@/i18n';
 import {toInteger} from 'lodash';
-import Merchandise from '@/components/smart/Merchandise.vue';
-import config from '../../app-config.json';
 
 type SellType = 'weapon' | 'character' | 'shield';
 type WeaponId = string;
@@ -776,8 +756,6 @@ interface Data {
   historyCounter: number;
   landSaleAllowed: boolean;
   reservedSaleAllowed: boolean;
-  isMerchandiseEnabled: boolean;
-  merchandiseSupportedChains: string[];
 }
 
 type StoreMappedState = Pick<IState, 'defaultAccount' | 'weapons' | 'characters' | 'shields'
@@ -847,7 +825,7 @@ interface StoreMappedActions {
 }
 
 export default Vue.extend({
-  components: { CharacterList, WeaponGrid, Hint, CurrencyConverter, NftList, Merchandise },
+  components: { CharacterList, WeaponGrid, Hint, CurrencyConverter, NftList },
 
   data() {
     return {
@@ -882,8 +860,6 @@ export default Vue.extend({
       historyCounter: 0,
       landSaleAllowed: false,
       reservedSaleAllowed: false,
-      isMerchandiseEnabled: merchandiseEnabled,
-      merchandiseSupportedChains: config.merchandiseSupportedChains,
     } as Data;
   },
 
@@ -2312,14 +2288,6 @@ export default Vue.extend({
       return input[0].toUpperCase() + input.slice(1);
     },
 
-    currentChainSupportsMerchandise() {
-      const currentChain = localStorage.getItem('currentChain') || 'BSC';
-      if (!currentChain || !this.merchandiseSupportedChains) {
-        return false;
-      }
-      return this.merchandiseSupportedChains.includes(currentChain);
-    },
-
   },
 
   watch: {
@@ -2461,14 +2429,6 @@ export default Vue.extend({
 }
 
 .special-offer-items {
-  height: 100%;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-}
-
-.merchandise-shop-items {
   height: 100%;
   width: 100%;
   display: flex;

--- a/frontend/src/views/Options.vue
+++ b/frontend/src/views/Options.vue
@@ -228,7 +228,7 @@ export default Vue.extend({
 
   methods: {
     ...(mapActions(['claimTokenRewards','setUpContracts','initialize','configureMetaMask','fetchPartnerProjects']) as StoreMappedActions),
-    ...mapMutations(['setNetworkId','updatePayoutCurrencyId']),
+    ...mapMutations(['setNetworkId','updatePayoutCurrencyId', 'updateCurrentChainSupportsMerchandise']),
     toggleGraphics() {
       this.showGraphics = !this.showGraphics;
       if (this.showGraphics) localStorage.setItem('useGraphics', 'true');
@@ -301,6 +301,7 @@ export default Vue.extend({
 
     async setCurrentChain() {
       localStorage.setItem('currentChain', this.currentChain);
+      this.updateCurrentChainSupportsMerchandise();
       Events.$emit('setting:currentChain', { value: this.currentChain });
       await this.configureMetaMask(+getConfigValue('VUE_APP_NETWORK_ID'));
     },


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?
When feature flag off:
![image](https://user-images.githubusercontent.com/34208222/150120277-d00afda6-94d4-4db8-b67a-72eded566fe1.png)

When feature flag on and chain supported:
![image](https://user-images.githubusercontent.com/34208222/150120383-428c7197-d261-44d2-b7fd-6ade1b47557a.png)

When chain not supported:
![image](https://user-images.githubusercontent.com/34208222/150120426-fb5fcd54-fd44-4930-885f-48c26d02dab8.png)

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Moves merchandise from market to viewlinks, adds security for the tab (example, route won't be available if chain is not supported or feature flag is disabled), adds appropriate tooltip and guidelines. On network change to supported chain it will be enabled 