### PR TITLE
use correct router instance

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -49,7 +49,7 @@ Vue.use(require('vue-script2'));
 Vue.use(Ads.Adsense);
 
 const store = createStore(web3);
-const router = createRouter();
+export const router = createRouter();
 
 new Vue({
   render: h => h(App),

--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -2,8 +2,7 @@ import axios from 'axios';
 import BigNumber from 'bignumber.js';
 import Web3 from 'web3';
 import config from '../../app-config.json';
-import createRouter from '../router';
-const router = createRouter();
+import {router} from '../main';
 
 BigNumber.config({ ROUNDING_MODE: BigNumber.ROUND_DOWN });
 BigNumber.config({ EXPONENTIAL_AT: 100 });


### PR DESCRIPTION
common.ts was creating it's own router instance so that router.replace could not add to params to current route, because the current route was always "/".