### PR TITLE
Add more exclamation mark options in stake pools

### DIFF
--- a/frontend/src/components/StakeSelectorItem.vue
+++ b/frontend/src/components/StakeSelectorItem.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="container">
     <span class="stake-header">
-      <b-icon-exclamation-circle
-      :class="getExclamationMark(rewardDistributionTimeLeft)"
-      v-tooltip="getTooltip(rewardDistributionTimeLeft)"/>
+      <b-icon-exclamation-circle scale="0.8"
+      :class="exclamationMark"
+      v-tooltip="rewardTooltip"/>
       <div class="stake-icon-wrapper">
         <img src="https://seiyria.com/gameicons-font/svg/two-coins.svg" alt="" class="stake-type-icon">
       </div>
@@ -81,7 +81,8 @@ export default {
     'estimatedYield',
     'rewardsDuration',
     'deprecated',
-    'rewardDistributionTimeLeft'
+    'rewardDistributionTimeLeft',
+    'currentRewardEarned'
   ],
   computed: {
     minimumStakeTimeFormatted() {
@@ -93,20 +94,31 @@ export default {
     rewardsDurationFormatted() {
       return formatDurationFromSeconds(this.rewardsDuration);
     },
-  },
-  methods: {
-    getExclamationMark(rewardDistributionTimeLeft) {
-      if(rewardDistributionTimeLeft > 0) {
-        return 'green-exclamation-mark';
-      }
-      return 'red-exclamation-mark';
-    },
+    exclamationMark() {
+      let exclamationMark = '';
 
-    getTooltip(rewardDistributionTimeLeft) {
-      if(rewardDistributionTimeLeft > 0) {
+      if (this.rewardDistributionTimeLeft > 0) {
+        exclamationMark += 'green-exclamation-mark ';
+      } else {
+        exclamationMark += 'red-exclamation-mark ';
+      }
+
+      if (this.currentRewardEarned > 0) {
+        exclamationMark += 'gold-background';
+      }
+      return exclamationMark;
+    },
+    rewardTooltip() {
+      if(this.rewardDistributionTimeLeft > 0) {
+        if (this.currentRewardEarned > 0) {
+          return this.$t('stake.StakeSelectorItem.rewardsAvailableEarnedTooltip');
+        }
         return this.$t('stake.StakeSelectorItem.rewardsAvailableTooltip');
       }
-      return this.$t('stake.StakeSelectorItem.rewardsUnavailableTooltip');
+      if (this.currentRewardEarned > 0) {
+        return this.$t('stake.StakeSelectorItem.rewardsDepletedEarnedTooltip');
+      }
+      return this.$t('stake.StakeSelectorItem.rewardsDepletedTooltip');
     },
   },
 };
@@ -184,17 +196,22 @@ export default {
 }
 
 .green-exclamation-mark {
-  float: left;
-  color: rgb(59, 155, 39);
+  float: right;
+  color: rgb(41, 107, 28);
 }
 
 .red-exclamation-mark {
-  float: left;
+  float: right;
   color: rgb(153, 29, 29);
+}
+
+.gold-background {
+  background: #9e8a57;
+  border-radius: 50%;
 }
 
 .stake-header {
   width: 100%;
-  font-size : 1.5em;
+  font-size : 1.9em;
 }
 </style>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -469,8 +469,8 @@
       "stakeLocked": "Stake gesperrt",
       "warning": "Warnung",
       "select": "Wählen",
-      "rewardsAvailableTooltip":"Rewards available",
-      "rewardsUnavailableTooltip":"Rewards depleted",
+      "rewardsAvailableTooltip":"You can earn rewards in this stake pool.",
+      "rewardsDepletedTooltip":"Rewards depleted.",
       "deprecatedTooltip": "Dieser Stake-Pool ist veraltet und in diesen sollte nicht mehr eingezahlt werden. Du kannst immernoch aus diesen auszahlen oder einzahlen, aber auf eigenes Risiko. Dies wird jedoch nicht empfohlen und kann nicht rückgängig gemacht werden."
     }
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -578,8 +578,10 @@
       "rewardsDuration": "Distribution",
       "warning": "Warning",
       "select": "Select",
-      "rewardsAvailableTooltip":"Rewards available",
-      "rewardsUnavailableTooltip":"Rewards depleted",
+      "rewardsAvailableTooltip":"You can earn rewards in this stake pool.",
+      "rewardsDepletedTooltip":"Rewards depleted.",
+      "rewardsAvailableEarnedTooltip":"You have rewards ready to claim in this stake pool and you can still earn more.",
+      "rewardsDepletedEarnedTooltip":"Rewards depleted but you can claim your reward.",
       "deprecatedTooltip": "This stake pool has been deprecated, and should not be staked in anymore. You can still pull tokens out or stake at your own risk, but it is not recommended, and it cannot be reversed."
     },
     "tier": "Tier",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -469,8 +469,8 @@
       "stakeLocked": "Stake locked",
       "warning": "Warning",
       "select": "Select",
-      "rewardsAvailableTooltip":"Rewards available",
-      "rewardsUnavailableTooltip":"Rewards depleted",
+      "rewardsAvailableTooltip":"You can earn rewards in this stake pool.",
+      "rewardsDepletedTooltip":"Rewards depleted.",
       "deprecatedTooltip": "This stake pool has been deprecated, and should not be staked in anymore. You can still pull tokens out or stake at your own risk, but it is not recommended, and it cannot be reversed."
     }
   },

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -469,8 +469,8 @@
       "stakeLocked": "Stake locked",
       "warning": "Warning",
       "select": "Select",
-      "rewardsAvailableTooltip":"Rewards available",
-      "rewardsUnavailableTooltip":"Rewards depleted",
+      "rewardsAvailableTooltip":"You can earn rewards in this stake pool.",
+      "rewardsDepletedTooltip":"Rewards depleted.",
       "deprecatedTooltip": "This stake pool has been deprecated, and should not be staked in anymore. You can still pull tokens out or stake at your own risk, but it is not recommended, and it cannot be reversed."
     }
   },

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -525,8 +525,8 @@
       "stakeLocked": "Stake locked",
       "warning": "Ostrzeżenie",
       "select": "Wybierz",
-      "rewardsAvailableTooltip":"Nagrody wciąż dostępne",
-      "rewardsUnavailableTooltip":"Aktualnie nagrody nie dostępne",
+      "rewardsAvailableTooltip":"Nagrody wciąż dostępne.",
+      "rewardsDepletedTooltip":"Aktualnie nagrody nie dostępne.",
       "deprecatedTooltip": "This stake pool has been deprecated, and should not be staked in anymore. You can still pull tokens out or stake at your own risk, but it is not recommended, and it cannot be reversed."
     },
     "pickId": "Wybierz ID",

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -2214,7 +2214,6 @@ export function createStore(web3: Web3) {
           StakingRewards.methods.getStakeRewardDistributionTimeLeft().call(defaultCallOptions(state)),
           StakingRewards.methods.getStakeUnlockTimeLeft().call(defaultCallOptions(state)),
         ]);
-
         const stakeData: { stakeType: StakeType | NftStakeType } & IStakeState = {
           stakeType,
           ownBalance,

--- a/frontend/src/views/SelectStakeType.vue
+++ b/frontend/src/views/SelectStakeType.vue
@@ -11,7 +11,8 @@
           :estimatedYield="estimatedYields[e.stakeType]"
           :rewardsDuration="stakeOverviews[e.stakeType].rewardsDuration"
           :deprecated="e.deprecated"
-          :rewardDistributionTimeLeft="stakeOverviews[e.stakeType].rewardDistributionTimeLeft" />
+          :rewardDistributionTimeLeft="stakeOverviews[e.stakeType].rewardDistributionTimeLeft"
+          :currentRewardEarned="staking[e.stakeType].currentRewardEarned"/>
       </li>
     </ul>
     <div class="loading-indicator" v-else>
@@ -37,7 +38,7 @@ export default {
   },
 
   computed: {
-    ...mapState(['stakeOverviews']),
+    ...mapState(['stakeOverviews', 'staking']),
     ...mapGetters(['availableStakeTypes', 'availableNftStakeTypes']),
 
     entries() {


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?
![rewards2](https://user-images.githubusercontent.com/38990293/150697057-26d69abd-6774-4998-9e90-5c64df738500.png)

### New Feature Submissions

* [x] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
#1068 
### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description
This PR adds gold background for exclamation mark in the stake pools which indicates that player has available rewards to claim.

Current tooltips:

- You have rewards ready to claim in this stake pool and you can still earn more. (green; gold background)
- You can earn rewards in this stake pool. (green)
- Rewards depleted but you can claim your reward. (red; gold background)
- Rewards depleted. (red)

I also moved exclamation marks to the right side as in most cases we have marks on the right side.