### PR TITLE
fix: fix invalid past block in kicked event

### DIFF
--- a/frontend/src/components/smart/PvPArena.vue
+++ b/frontend/src/components/smart/PvPArena.vue
@@ -281,7 +281,7 @@ export default {
       let fromBlock = blockToScanFrom;
 
       if (!blockToScanFrom) {
-        fromBlock = await this.web3.eth.getBlockNumber() - 4800;
+        fromBlock = Math.max(await this.web3.eth.getBlockNumber() - 4800, 0);
       }
 
       const kickedEvents = await pvpContract.getPastEvents('CharacterKicked', {


### PR DESCRIPTION
This PR:

Fixes the frontend breaking on newer chains (and local nodes, mainly used in development).