### PR TITLE
Gas optimization: PvpArena.performDuels() uses getTrait() directly

### DIFF
--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -519,9 +519,8 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             if (fighterByCharacter[attackerID].useShield) {
                 uint24 attackerShieldDefense = 3;
 
-                (, , , uint8 attackerShieldTrait) = shields.getFightData(
-                    fighterByCharacter[attackerID].shieldID,
-                    attackerTrait
+                uint8 attackerShieldTrait = shields.getTrait(
+                    fighterByCharacter[attackerID].shieldID
                 );
 
                 if (
@@ -543,9 +542,8 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             if (fighterByCharacter[defenderID].useShield) {
                 uint24 defenderShieldDefense = 3;
 
-                (, , , uint8 defenderShieldTrait) = shields.getFightData(
-                    fighterByCharacter[defenderID].shieldID,
-                    defenderTrait
+                uint8 defenderShieldTrait = shields.getTrait(
+                    fighterByCharacter[defenderID].shieldID
                 );
 
                 if (


### PR DESCRIPTION
Estimated gas savings: 10k gas per shield (so 0-20k gas per duel)