### PR TITLE
Issue 1055

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,32 +33,27 @@
         </div>
         <div class="seperator"></div>
         <div class="instructions-list">
-          <p>{{ $t('app.warning.message.instructions', {recruitCost: this.recruitCost}) }}</p>
+          <p>{{ $t('app.warning.message.' + currentChain + '.instructions', {recruitCost: this.recruitCost}) }}</p>
           <ul class="unstyled-list">
             <li>
-              1. {{ $t('app.warning.message.inst1') }}
-              <a href="https://youtu.be/6-sUDUE2RPA" target="_blank" rel="noopener noreferrer">{{$t('app.warning.message.watchVideo')}}</a>
-              {{$t('app.warning.message.or')}}
-              <a :href="getExchangeTransakUrl()" target="_blank" rel="noopener noreferrer">{{$t('app.warning.message.buyWithTransak')}}</a>
+              <span v-html="$t('app.warning.message.' + currentChain + '.inst1', {link1: getExchangeTransakUrl()})"></span>
             </li>
             <li>
-              2. {{ $t('app.warning.message.inst2') }}<br />
-              <a v-bind:href="`${getExchangeUrl}`" target="_blank">{{ $t('trade') }} SKILL/BNB</a>
+              <span v-html="$t('app.warning.message.' + currentChain + '.inst2', {link1: getExchangeUrl})"></span>
             </li>
             <li>
-              3. {{ $t('app.warning.message.inst3') }} <a href="https://youtu.be/_zitrvJ7Hl4" target="_blank" rel="noopener noreferrer">{{ $t('app.warning.message.watchVideo', {name:''}) }}</a>
+              <span v-html="$t('app.warning.message.' + currentChain + '.inst3')"></span>
             </li>
             <li>
-              4. {{ $t('app.warning.message.inst4') }} (<a href="https://youtu.be/ZcNq0jCa28c" target="_blank" rel="noopener noreferrer">{{ $t('app.warning.message.watchGettingStartedVideo', {name:"'Getting Started' "}) }}</a>)
+              <span v-html="$t('app.warning.message.' + currentChain + '.inst4')"></span>
             </li>
           </ul>
           <p>
-            {{ $t('app.warning.message.questionDiscord') }}
-            <a href="https://discord.gg/cryptoblades" target="_blank" rel="noopener noreferrer">https://discord.gg/cryptoblades</a>
+            {{ $t('app.warning.message.happyEarning') }}
           </p>
         </div>
         <div class="seperator"></div>
-        <small-button class="button" @click="toggleHideWalletWarning" :text="$t('app.warning.buttons.hide')" />
+        <small-button class="button mm-button" @click="toggleHideWalletWarning" :text="$t('app.warning.buttons.hide')" />
       </div>
       <div class="ad-container">
         <Adsense v-if="showAds && !isMobile()"
@@ -129,6 +124,9 @@ export default {
     showNetworkError() {
       return this.expectedNetworkId && this.currentNetworkId !== null && this.currentNetworkId !== this.expectedNetworkId;
     },
+    currentChain(){
+      return localStorage.getItem('currentChain');
+    }
   },
 
   watch: {
@@ -549,10 +547,12 @@ button.close {
   color: #9e8a57 !important;
 }
 
-.mm-button {
+.mm-button{
   margin: 5px;
-  margin-left: 5px;
-  margin-right: 5px;
+  font-size: clamp(24px, 2vw, 40px);
+}
+.mm-button > h1 {
+   font-size: clamp(24px, 2vw, 40px);
 }
 
 .btn {
@@ -700,7 +700,7 @@ div.bg-success {
 
 .starter-panel-heading {
   margin-left: 15px;
-  font-size: 45px;
+  font-size: clamp(18px, 2vw, 45px);
 }
 
 .starter-msg {
@@ -709,11 +709,12 @@ div.bg-success {
 .instructions-list {
   text-align: start;
   padding: 15px;
-  font-size: 0.5em;
+  font-size: clamp(18px, 2vw, 24px);
 }
 
 .unstyled-list {
   list-style-type: none;
+  padding-left: clamp(10px,2vw,40px);
 }
 .seperator {
   border: 1px solid #9e8a57;
@@ -722,8 +723,7 @@ div.bg-success {
 }
 
 .mini-icon-starter {
-  height: 1.2em;
-  width: 1.2em;
+  width: clamp(50px, 4vw, 100px);
   margin: 5px;
 }
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -672,38 +672,38 @@
       "message": {
         "BSC":{
           "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .0015 BNB als gas. Außerdem brauchst du noch etwas BNB als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
-          "inst1": "1. Kaufe BNB mit fiat: <a href=https://youtu.be/6-sUDUE2RPA> Video </a> or <a href={link1}> Mit Transak kaufen</a>",
-          "inst2": "2. Sobald du BNB hast, gehe zu ApeSwap, um SKILL Tokens zu tauschen: <a href={link1}> Tausche SKILL/BNB </a>",
-          "inst3": "3. Schaue dir dieses Tutorial, um BNB zu SKILL zu tauschen: <a href=https://youtu.be/_zitrvJ7Hl4> Watch Video </a>",
-          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+          "inst1": "1. Kaufe BNB mit fiat: <a target=_blank href=https://youtu.be/6-sUDUE2RPA> Video </a> or <a target=_blank href={link1}> Mit Transak kaufen</a>",
+          "inst2": "2. Sobald du BNB hast, gehe zu ApeSwap, um SKILL Tokens zu tauschen: <a target=_blank href={link1}> Tausche SKILL/BNB </a>",
+          "inst3": "3. Schaue dir dieses Tutorial, um BNB zu SKILL zu tauschen: <a target=_blank href=https://youtu.be/_zitrvJ7Hl4> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a target=_blank href=https://discord.gg/cryptoblades> Join Discord </a>"
         },
         "HECO":{
           "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .0007 HT als gas. Außerdem brauchst du noch etwas HT als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
-          "inst1": "1. Tausche BNB zu HT <a href=https://bridge.butterswap.me> hier </a> (min.  BNB im Wert von $30USD)",
-          "inst2": "2. Sobald du HT hast, gehe zu <a href=https://swap.butterswap.me/swap> ButterSwap </a>, um HT zu SKILL zu tauschen",
-          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
-          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a href=https://discord.gg/cryptoblades> Discord </a>"
+          "inst1": "1. Tausche BNB zu HT <a target=_blank href=https://bridge.butterswap.me> hier </a> (min.  BNB im Wert von $30USD)",
+          "inst2": "2. Sobald du HT hast, gehe zu <a target=_blank href=https://swap.butterswap.me/swap> ButterSwap </a>, um HT zu SKILL zu tauschen",
+          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a target=_blank href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
+          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a target=_blank href=https://discord.gg/cryptoblades> Discord </a>"
         },
         "OEC":{
           "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .000032 OKT als gas. Außerdem brauchst du noch etwas OKT als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
-          "inst1": "1. Wie du OKT in deine Wallet bekommst:<a href=https://www.youtube.com/watch?v=eMXUYGl7XYg> Video </a>",
-          "inst2": "2. Wenn du OKT hast und SKILL brauchst: <a href=https://app.jswap.finance/#/swap?outputCurrency=0xcC137b0713E0DC63b1fA136272014F2A54Dd7aCB> zu JSwap </a>", 
-          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
-          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a href=https://discord.gg/cryptoblades>  Discord </a>"
+          "inst1": "1. Wie du OKT in deine Wallet bekommst:<a target=_blank href=https://www.youtube.com/watch?v=eMXUYGl7XYg> Video </a>",
+          "inst2": "2. Wenn du OKT hast und SKILL brauchst: <a target=_blank href=https://app.jswap.finance/#/swap?outputCurrency=0xcC137b0713E0DC63b1fA136272014F2A54Dd7aCB> zu JSwap </a>", 
+          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a target=_blank href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
+          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a target=_blank href=https://discord.gg/cryptoblades>  Discord </a>"
         },
         "POLYGON":{
           "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .01 MATIC als gas. Außerdem brauchst du noch etwas MATIC als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
-          "inst1": "1. Tausche SKILL zwischen den Netzwerken: <a href=https://bridge.poly.network/token/SKILL> hier </a>",
-          "inst2": "2. Tausche SKILL zu  MATIC: <a href=https://app.apeswap.finance/swap> hier <a>", 
-          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
-          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a href=https://discord.gg/cryptoblades>  Discord </a>"
+          "inst1": "1. Tausche SKILL zwischen den Netzwerken: <a target=_blank href=https://bridge.poly.network/token/SKILL> hier </a>",
+          "inst2": "2. Tausche SKILL zu  MATIC: <a target=_blank href=https://app.apeswap.finance/swap> hier <a>", 
+          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a target=_blank href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
+          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a target=_blank href=https://discord.gg/cryptoblades>  Discord </a>"
         },
         "AVAX":{
           "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .001 AVAX als gas. Außerdem brauchst du noch etwas AVAX als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
-          "inst1": "1. Tausche SKILL zwischen den Netzwerken: <a href=https://bridge.poly.network/token/SKILL> hier </a>",
-          "inst2": "2. Tausche SKILL zu AVAX: <a href=https://app.pangolin.exchange/#/swap> hier <a>", 
-          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
-          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a href=https://discord.gg/cryptoblades>  Discord </a>"
+          "inst1": "1. Tausche SKILL zwischen den Netzwerken: <a target=_blank href=https://bridge.poly.network/token/SKILL> hier </a>",
+          "inst2": "2. Tausche SKILL zu AVAX: <a target=_blank href=https://app.pangolin.exchange/#/swap> hier <a>", 
+          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a target=_blank href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
+          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a target=_blank href=https://discord.gg/cryptoblades>  Discord </a>"
         },
         "hideWalletWarning": "Du hast die Wallet-Warnung ausgeblendet und diese würde jetzt angezeigt werden. Falls du nicht spielen kannst, gehe in die Einstellungen und aktiviere die Wallet-Warnung. Folge dann den angezeigten Schritten.",
         "happyEarning": "Viel Spaß beim Verdienen!",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -667,20 +667,48 @@
         "connecting": "Connecting to MetaMask...",
         "success": "Success: MetaMask connected.",
         "error": "Error: MetaMask could not get permissions.",
-        "welcome": "Welcome to CryptoBlades. Here is how you can get started."
+        "welcome": "Willkommen zu Cryptoblades!"
       },
       "message": {
+        "BSC":{
+          "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .0015 BNB als gas. Außerdem brauchst du noch etwas BNB als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
+          "inst1": "1. Kaufe BNB mit fiat: <a href=https://youtu.be/6-sUDUE2RPA> Video </a> or <a href={link1}> Mit Transak kaufen</a>",
+          "inst2": "2. Sobald du BNB hast, gehe zu ApeSwap, um SKILL Tokens zu tauschen: <a href={link1}> Tausche SKILL/BNB </a>",
+          "inst3": "3. Schaue dir dieses Tutorial, um BNB zu SKILL zu tauschen: <a href=https://youtu.be/_zitrvJ7Hl4> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+        },
+        "HECO":{
+          "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .0007 HT als gas. Außerdem brauchst du noch etwas HT als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
+          "inst1": "1. Tausche BNB zu HT <a href=https://bridge.butterswap.me> hier </a> (min.  BNB im Wert von $30USD)",
+          "inst2": "2. Sobald du HT hast, gehe zu <a href=https://swap.butterswap.me/swap> ButterSwap </a>, um HT zu SKILL zu tauschen",
+          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
+          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a href=https://discord.gg/cryptoblades> Discord </a>"
+        },
+        "OEC":{
+          "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .000032 OKT als gas. Außerdem brauchst du noch etwas OKT als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
+          "inst1": "1. Wie du OKT in deine Wallet bekommst:<a href=https://www.youtube.com/watch?v=eMXUYGl7XYg> Video </a>",
+          "inst2": "2. Wenn du OKT hast und SKILL brauchst: <a href=https://app.jswap.finance/#/swap?outputCurrency=0xcC137b0713E0DC63b1fA136272014F2A54Dd7aCB> zu JSwap </a>", 
+          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
+          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a href=https://discord.gg/cryptoblades>  Discord </a>"
+        },
+        "POLYGON":{
+          "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .01 MATIC als gas. Außerdem brauchst du noch etwas MATIC als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
+          "inst1": "1. Tausche SKILL zwischen den Netzwerken: <a href=https://bridge.poly.network/token/SKILL> hier </a>",
+          "inst2": "2. Tausche SKILL zu  MATIC: <a href=https://app.apeswap.finance/swap> hier <a>", 
+          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
+          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a href=https://discord.gg/cryptoblades>  Discord </a>"
+        },
+        "AVAX":{
+          "instructions": "Fange im Nullkommanichts an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und .001 AVAX als gas. Außerdem brauchst du noch etwas AVAX als gas, um deine ersten Kämpfe auszuführen,aber keine Angst, du profitierst direkt durch Belohnungen, die du beim Kämpfen erhältst!",
+          "inst1": "1. Tausche SKILL zwischen den Netzwerken: <a href=https://bridge.poly.network/token/SKILL> hier </a>",
+          "inst2": "2. Tausche SKILL zu AVAX: <a href=https://app.pangolin.exchange/#/swap> hier <a>", 
+          "inst3": "3. Falls du deine NFTs zwischen den Netzwerken/Chains versenden willst, brauchst du unsere Bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Video </a>",
+          "inst4": "4. Das war's! Wenn du Fragen hast tritt bitte unserem Discord Server bei!: <a href=https://discord.gg/cryptoblades>  Discord </a>"
+        },
         "hideWalletWarning": "Du hast die Wallet-Warnung ausgeblendet und diese würde jetzt angezeigt werden. Falls du nicht spielen kannst, gehe in die Einstellungen und aktiviere die Wallet-Warnung. Folge dann den angezeigten Schritten.",
-        "instructions": "Fange in weniger als 10 Minuten an! Um deinen ersten Charakter zu rekrutieren, brauchst du {recruitCost} SKILL und mindestens 0.001 BNB für gas (Transaktionsgebühr). Außerdem brauchst du etwas BNB für deine ersten Kämpfe (0.0015 BNB), aber keine Sorge du wirst die Gebühr durch SKILL wieder verdienen!",
-        "inst1": "BNB mit FIAT kaufen:",
-        "inst2": "Sobald du BNB hast, gehe zu ApeSwap und hole dir SKILL tokens:",
-        "inst3": "Hier ein Tutorial wie man BNB zu SKILL tauscht:",
-        "inst4": "Das war's! Du kannst jetzt deinen ersten Charakter rekrutieren:",
-        "watchVideo": "Video anschauen",
-        "watchGettingStartedVideo": "Watch 'Getting Started' Video",
-        "or": "oder",
-        "buyWithTransak": "Mit Transak kaufen",
-        "questionDiscord": "Wenn du Fragen hast, tritt gerne unserem Discord bei:"
+        "happyEarning": "Viel Spaß beim Verdienen!",
+        "newCharacter": "New character",
+        "inGarrison:": "appeared in Garrison"
       }
     },
     "notification": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -811,20 +811,46 @@
         "connecting": "Connecting to MetaMask...",
         "success": "Success: MetaMask connected.",
         "error": "Error: MetaMask could not get permissions.",
-        "welcome": "Welcome to CryptoBlades. Here is how you can get started."
+        "welcome": "Get started With CryptoBlades"
       },
       "message": {
+        "BSC":{
+          "instructions": "Get started in no time! To recruit your first character you need {recruitCost} SKILL and .0015 BNB for gas. You will also need a litle bit of BNB for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
+          "inst1": "1. Buying BNB with fiat: <a href=https://youtu.be/6-sUDUE2RPA> Watch Video </a> or <a href={link1}> Buy with Transak</a>",
+          "inst2": "2. Once you have BNB, go to ApeSwap to obtain SKILL tokens: <a href={link1}> Trade SKILL/BNB </a>",
+          "inst3": "3. Follow this tutorial to swap BNB for SKILL: <a href=https://youtu.be/_zitrvJ7Hl4> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+        },
+        "HECO":{
+          "instructions": "Get started in no time! To recruit your first character you need {recruitCost} SKILL and .0007 HT for gas. You will also need a litle bit of HT for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
+          "inst1": "1. Swap BNB to HT <a href=https://bridge.butterswap.me> here </a> (min. $30USD worth of BNB)",
+          "inst2": "2. Once you have HT, go to <a href=https://swap.butterswap.me/swap> ButterSwap </a> to swap HT for SKILL tokens",
+          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+        },
+        "OEC":{
+          "instructions": "Get started in no time! To recruit your first character, you need {recruitCost} SKILL and .000032 OKT for gas. You will also need a little bit of OKT for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
+          "inst1": "1. Getting OKT to your wallet:<a href=https://www.youtube.com/watch?v=eMXUYGl7XYg> Watch Video </a>",
+          "inst2": "2. If you have OKT but just need SKILL: <a href=https://app.jswap.finance/#/swap?outputCurrency=0xcC137b0713E0DC63b1fA136272014F2A54Dd7aCB> go to JSwap </a>", 
+          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+        },
+        "POLYGON":{
+          "instructions": "Get started in no time! To recruit your first character you need {recruitCost} SKILL and .01 MATIC for gas. You will also need a litle bit of MATIC for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
+          "inst1": "1. Trade SKILL between chains: <a href=https://bridge.poly.network/token/SKILL> here </a>",
+          "inst2": "2. SWAP SKILL to MATIC: <a href=https://app.apeswap.finance/swap> here <a>", 
+          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+        },
+        "AVAX":{
+          "instructions": "Get started in no time! To recruit your first character you need {recruitCost} SKILL and .001 AVAX for gas. You will also need a litle bit of AVAX for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
+          "inst1": "1. Trade SKILL between chains: <a href=https://bridge.poly.network/token/SKILL> here </a>",
+          "inst2": "2. SWAP SKILL to AVAX: <a href=https://app.pangolin.exchange/#/swap> here <a>", 
+          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+        },
         "hideWalletWarning": "You have hidden the wallet warning and it would now be displayed. If you are trying to play, please disable the option and follow the instructions, otherwise close and ignore.",
-        "instructions": "Get started in less than 10 minutes! To recruit your first character you need {recruitCost} SKILL and .001 BNB for gas. You will also need .0015 BNB to do your first few battles, but don't worry, you earn the battle fees back in SKILL rewards immediately!",
-        "inst1": "Buying BNB with fiat:",
-        "inst2": "Once you have BNB, go to ApeSwap to obtain SKILL tokens:",
-        "inst3": "Follow this tutorial to swap BNB for SKILL:",
-        "inst4": "That's it! Now you can create your first character:",
-        "watchVideo": "Watch Video",
-        "watchGettingStartedVideo": "Watch 'Getting Started' Video",
-        "or": "or",
-        "buyWithTransak": "Buy with Transak",
-        "questionDiscord": "If you have any questions, please join our Discord:",
+        "happyEarning": "Happy Earning!",
         "newCharacter": "New character",
         "inGarrison:": "appeared in Garrison"
       }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -816,38 +816,38 @@
       "message": {
         "BSC":{
           "instructions": "Get started in no time! To recruit your first character you need {recruitCost} SKILL and .0015 BNB for gas. You will also need a litle bit of BNB for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
-          "inst1": "1. Buying BNB with fiat: <a href=https://youtu.be/6-sUDUE2RPA> Watch Video </a> or <a href={link1}> Buy with Transak</a>",
-          "inst2": "2. Once you have BNB, go to ApeSwap to obtain SKILL tokens: <a href={link1}> Trade SKILL/BNB </a>",
-          "inst3": "3. Follow this tutorial to swap BNB for SKILL: <a href=https://youtu.be/_zitrvJ7Hl4> Watch Video </a>",
-          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+          "inst1": "1. Buying BNB with fiat: <a target=_blank href=https://youtu.be/6-sUDUE2RPA> Watch Video </a> or <a target=_blank href={link1}> Buy with Transak</a>",
+          "inst2": "2. Once you have BNB, go to ApeSwap to obtain SKILL tokens: <a target=_blank href={link1}> Trade SKILL/BNB </a>",
+          "inst3": "3. Follow this tutorial to swap BNB for SKILL: <a target=_blank href=https://youtu.be/_zitrvJ7Hl4> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a target=_blank href=https://discord.gg/cryptoblades> Join Discord </a>"
         },
         "HECO":{
           "instructions": "Get started in no time! To recruit your first character you need {recruitCost} SKILL and .0007 HT for gas. You will also need a litle bit of HT for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
-          "inst1": "1. Swap BNB to HT <a href=https://bridge.butterswap.me> here </a> (min. $30USD worth of BNB)",
-          "inst2": "2. Once you have HT, go to <a href=https://swap.butterswap.me/swap> ButterSwap </a> to swap HT for SKILL tokens",
-          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
-          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+          "inst1": "1. Swap BNB to HT <a target=_blank href=https://bridge.butterswap.me> here </a> (min. $30USD worth of BNB)",
+          "inst2": "2. Once you have HT, go to <a target=_blank href=https://swap.butterswap.me/swap> ButterSwap </a> to swap HT for SKILL tokens",
+          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a target=_blank href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a target=_blank href=https://discord.gg/cryptoblades> Join Discord </a>"
         },
         "OEC":{
           "instructions": "Get started in no time! To recruit your first character, you need {recruitCost} SKILL and .000032 OKT for gas. You will also need a little bit of OKT for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
-          "inst1": "1. Getting OKT to your wallet:<a href=https://www.youtube.com/watch?v=eMXUYGl7XYg> Watch Video </a>",
-          "inst2": "2. If you have OKT but just need SKILL: <a href=https://app.jswap.finance/#/swap?outputCurrency=0xcC137b0713E0DC63b1fA136272014F2A54Dd7aCB> go to JSwap </a>", 
-          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
-          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+          "inst1": "1. Getting OKT to your wallet:<a target=_blank href=https://www.youtube.com/watch?v=eMXUYGl7XYg> Watch Video </a>",
+          "inst2": "2. If you have OKT but just need SKILL: <a target=_blank href=https://app.jswap.finance/#/swap?outputCurrency=0xcC137b0713E0DC63b1fA136272014F2A54Dd7aCB> go to JSwap </a>", 
+          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a target=_blank href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a target=_blank href=https://discord.gg/cryptoblades> Join Discord </a>"
         },
         "POLYGON":{
           "instructions": "Get started in no time! To recruit your first character you need {recruitCost} SKILL and .01 MATIC for gas. You will also need a litle bit of MATIC for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
-          "inst1": "1. Trade SKILL between chains: <a href=https://bridge.poly.network/token/SKILL> here </a>",
-          "inst2": "2. SWAP SKILL to MATIC: <a href=https://app.apeswap.finance/swap> here <a>", 
-          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
-          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+          "inst1": "1. Trade SKILL between chains: <a target=_blank href=https://bridge.poly.network/token/SKILL> here </a>",
+          "inst2": "2. SWAP SKILL to MATIC: <a target=_blank href=https://app.apeswap.finance/swap> here <a>", 
+          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a target=_blank href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a target=_blank href=https://discord.gg/cryptoblades> Join Discord </a>"
         },
         "AVAX":{
           "instructions": "Get started in no time! To recruit your first character you need {recruitCost} SKILL and .001 AVAX for gas. You will also need a litle bit of AVAX for gas to cover your first few battles, but don't worry, you will profit with rewards immediately!",
-          "inst1": "1. Trade SKILL between chains: <a href=https://bridge.poly.network/token/SKILL> here </a>",
-          "inst2": "2. SWAP SKILL to AVAX: <a href=https://app.pangolin.exchange/#/swap> here <a>", 
-          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
-          "inst4": "4. That's it! If you have any questions, please join our Discord: <a href=https://discord.gg/cryptoblades> Join Discord </a>"
+          "inst1": "1. Trade SKILL between chains: <a target=_blank href=https://bridge.poly.network/token/SKILL> here </a>",
+          "inst2": "2. SWAP SKILL to AVAX: <a target=_blank href=https://app.pangolin.exchange/#/swap> here <a>", 
+          "inst3": "3. If you need to bridge NFTs to or from other networks, use our bridge: <a target=_blank href=https://www.youtube.com/watch?v=eNqh7b7hJwE&t=66s> Watch Video </a>",
+          "inst4": "4. That's it! If you have any questions, please join our Discord: <a target=_blank href=https://discord.gg/cryptoblades> Join Discord </a>"
         },
         "hideWalletWarning": "You have hidden the wallet warning and it would now be displayed. If you are trying to play, please disable the option and follow the instructions, otherwise close and ignore.",
         "happyEarning": "Happy Earning!",


### PR DESCRIPTION
- resolves issue #1055
- The instructions in the wallet-warning modal are now refering to the text of each chain by using `currentChain` from localStorage (if none is set, e.g. on first visit, BSC is used), e.g.: https://github.com/CryptoBlades/cryptoblades/blob/41e2eea00c34bd978d8f01611dd8eff11b0bee27/frontend/src/App.vue#L36
- changed the text for oec like request in #1055 
- BSC instructions unchanged 
- Other instructions for AVAX,HECO,POLY added according to the discord faqs
- Used clamp to change the css ( esp. for mobile) like so:

### Mobile
Before:
![image](https://user-images.githubusercontent.com/5601589/151559825-b64fde04-1235-4583-931c-7060933be653.png)
Now:
![image](https://user-images.githubusercontent.com/5601589/151559836-91ee9537-d9e4-4f48-8c4c-59a7107c45b0.png)

### Desktop
Before:
![image](https://user-images.githubusercontent.com/5601589/151559902-1c30f3b8-1f06-49ff-8869-c65ae42e4b0d.png)
Now:
![image](https://user-images.githubusercontent.com/5601589/151559906-7cf4d133-5b57-4641-98fd-e8f64f163c79.png)


