### PR TITLE
Simplify unnecessary call to characters.ownerOf() in _assignOpponent()

### DIFF
--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -891,7 +891,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             }
             if (
                 characters.ownerOf(candidateID) ==
-                characters.ownerOf(characterID)
+                msg.sender
             ) {
                 continue;
             }


### PR DESCRIPTION
Saves 5864 gas to remove a call to `ownerOf` when the response will always be `msg.sender` due to `isCharacterOwner` modifier applied to both callers: `findOpponent()` and `reRollOpponent()`.