### PR TITLE
Add getDefenseMultiplierForTrait() variant to shields.sol

### DIFF
--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -1068,7 +1068,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
     {
         uint8 trait = characters.getTrait(characterID);
         uint256 shieldID = fighterByCharacter[characterID].shieldID;
-        (, int128 shieldMultFight, , ) = shields.getFightData(shieldID, trait);
+        int128 shieldMultFight = shields.getDefenseMultiplierForTrait(shieldID, trait);
         return (shieldMultFight);
     }
 

--- a/contracts/shields.sol
+++ b/contracts/shields.sol
@@ -392,6 +392,11 @@ contract Shields is Initializable, ERC721Upgradeable, AccessControlUpgradeable {
         return result;
     }
 
+    function getDefenseMultiplierForTrait(uint256 id, uint8 trait) public view returns(int128) {
+        Shield storage shd = tokens[id];
+        return getDefenseMultiplierForTrait(shd.properties, shd.stat1, shd.stat2, shd.stat3, trait);
+    }
+
     function getFightData(uint256 id, uint8 charTrait) public view noFreshLookup(id) returns (int128, int128, uint24, uint8) {
         Shield storage shd = tokens[id];
         return (


### PR DESCRIPTION
External calls to `shields.getFightData()` cost 15479 gas.  PvpArena only uses one of the four return values.

This change adds a `getDefenseMultiplierForTrait()` variant so that PvpArena can call it directly.