### PR TITLE
Oracle gas improvement for price conversion

### DIFF
--- a/contracts/BasicPriceOracle.sol
+++ b/contracts/BasicPriceOracle.sol
@@ -3,12 +3,15 @@ pragma solidity ^0.6.5;
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "./interfaces/IPriceOracle.sol";
+import "./interfaces/IPriceListener.sol";
 
 contract BasicPriceOracle is IPriceOracle, Initializable, AccessControlUpgradeable {
     bytes32 public constant PRICE_UPDATER = keccak256("PRICE_UPDATER");
+    bytes32 public constant REGISTER_LISTENER = keccak256("REGISTER_LISTENER");
 
     bool private priceSet;
     uint256 private currentPrice_;
+    IPriceListener[] private listeners;
 
     function initialize() public initializer {
         __AccessControl_init();
@@ -20,6 +23,9 @@ contract BasicPriceOracle is IPriceOracle, Initializable, AccessControlUpgradeab
         currentPrice_ = 0;
     }
 
+    // TODO: Add migration
+    //      _setupRole(REGISTER_LISTENER, ...);
+
     // Views
     function currentPrice() external override view returns (uint256) {
         require(priceSet, "Price must be set beforehand");
@@ -27,6 +33,14 @@ contract BasicPriceOracle is IPriceOracle, Initializable, AccessControlUpgradeab
     }
 
     // Mutative
+    function registerListener(IPriceListener listener) external override {
+        require(hasRole(REGISTER_LISTENER, _msgSender()), "Missing REGISTER_LISTENER role");
+        require(address(listener) != address(0));
+        listeners.push(listener);
+        // This serves both set initial price and to validate the listener.
+        listener.speakCurrentPrice(currentPrice_);
+    }
+
     function setCurrentPrice(uint256 _currentPrice) external override {
         require(hasRole(PRICE_UPDATER, _msgSender()), "Missing PRICE_UPDATER role");
         require(_currentPrice > 0, "Price must be non-zero");
@@ -35,6 +49,10 @@ contract BasicPriceOracle is IPriceOracle, Initializable, AccessControlUpgradeab
         currentPrice_ = _currentPrice;
 
         emit CurrentPriceUpdated(_currentPrice);
+
+        for(uint i = 0; i < listeners.length; i++) {
+            listeners[i].speakCurrentPrice(currentPrice_);
+        }
     }
 
     // Events

--- a/contracts/interfaces/IPriceListener.sol
+++ b/contracts/interfaces/IPriceListener.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.6.5;
+
+interface IPriceListener {
+    function speakCurrentPrice(uint256 price) external;
+}

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -1,10 +1,13 @@
 pragma solidity ^0.6.5;
 
+import "./IPriceListener.sol";
+
 interface IPriceOracle {
     // Views
     function currentPrice() external view returns (uint256 price);
 
     // Mutative
+    function registerListener(IPriceListener listener) external;
     function setCurrentPrice(uint256 price) external;
 
     // Events


### PR DESCRIPTION
The following contracts have at least one price oracle member and use the oracle `currentPrice()` method whenever doing conversions for at least 5,000 gas per call:
- Blacksmith.sol
- cryptoblades.sol
- NFTMarket

The following contracts invoke the oracle `currentPrice()` method via the game contract (cryptoblades.sol) at a cost of at least 10,000 gas per call:
- PvpArena.sol
- raid1.sol

This change introduces registration to the `IPriceOracle` (using a new `IPriceListener` interface) to allow consumers of pricing be notified ("push") of price updates so that they no longer have to query ("pull") to obtain the pricing.

With this change none of the above contracts invoke `currentPrice()` and thus player-invoked methods no longer pay gas to obtain the current pricing.

The caller of `setCurrentPrice()` on oracles now pays a bit more to update all of the registered listeners to provide this service to them.