### PR TITLE
removed unused constant, cut weapon transfer killswitch

### DIFF
--- a/contracts/characters.sol
+++ b/contracts/characters.sol
@@ -14,7 +14,6 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
 
     bytes32 public constant GAME_ADMIN = keccak256("GAME_ADMIN");
     bytes32 public constant NO_OWNED_LIMIT = keccak256("NO_OWNED_LIMIT");
-    bytes32 public constant RECEIVE_DOES_NOT_SET_TRANSFER_TIMESTAMP = keccak256("RECEIVE_DOES_NOT_SET_TRANSFER_TIMESTAMP");
 
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 


### PR DESCRIPTION
Removes the overly paranoid killswitch that only affects transfers. This kind of thing might make sense for minting, but we can just revoke the game_admin role of the offending contract to kill it if necessary.
Feature flags may return later if we find a use for them.

This reduces weapons contract size by 0.38kb, and characters contract by 0.08kb.
The tweak to the beforeTransfer function in weapons will save ~380 gas on minting and transferring (no noteworthy change on burning).