### PR TITLE
Revoke admin role

### DIFF
--- a/frontend/src/components/ViewLinks.vue
+++ b/frontend/src/components/ViewLinks.vue
@@ -111,10 +111,10 @@ export default Vue.extend({
   },
 
   methods: {
-    ...mapActions(['userHasAnyAdminAccess']),
+    ...mapActions(['userHasAnyAdminAccess', 'userHasAnyMinterAccess']),
 
     async fetchData() {
-      this.hasAdminAccess = await this.userHasAnyAdminAccess();
+      this.hasAdminAccess = await this.userHasAnyAdminAccess() || await this.userHasAnyMinterAccess();
     },
   },
 

--- a/frontend/src/components/smart/AdminMaker.vue
+++ b/frontend/src/components/smart/AdminMaker.vue
@@ -2,7 +2,7 @@
   <div class="d-flex flex-column align-items-start gap-2 p-1">
     <h2 class="m-0">{{ $t('admin.grantGameAdminRole') }}</h2>
     <b-form-input v-model="walletAddress" :placeholder="$t('admin.pasteInValidWalletAddress')"/>
-    <b-button variant="primary" @click="onSubmit" :disabled="!isValidWeb3Address || isLoading">
+    <b-button variant="primary" @click="onSubmit" :disabled="!isValidWeb3Address(walletAddress) || isLoading">
       {{ $t('admin.grantRole') }}
     </b-button>
   </div>

--- a/frontend/src/components/smart/AdminRevoker.vue
+++ b/frontend/src/components/smart/AdminRevoker.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="d-flex flex-column align-items-start gap-2 p-1">
+    <h2 class="m-0">{{ $t('admin.revokeGameAdminRole') }}</h2>
+    <b-form-input v-model="walletAddress" :placeholder="$t('admin.pasteInValidWalletAddress')"/>
+    <b-button variant="primary" @click="onSubmit" :disabled="!isValidWeb3Address(walletAddress) || isLoading">
+      {{ $t('admin.revokeRole') }}
+    </b-button>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import {mapActions} from 'vuex';
+import {Contract} from '@/interfaces';
+import {PropType} from 'vue/types/options';
+import {isValidWeb3Address} from '@/utils/common';
+
+interface StoreMappedActions {
+  revokeGameAdminRole(payload: { walletAddress: string, contract: Contract<any> }): Promise<void>;
+}
+
+interface Data {
+  walletAddress: string;
+  isLoading: boolean;
+}
+
+export default Vue.extend({
+  props: {
+    contract: {
+      type: Object as PropType<Contract<any>>,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      walletAddress: '',
+      isLoading: false,
+      isValidWeb3Address
+    } as Data;
+  },
+
+  methods: {
+    ...mapActions(['revokeGameAdminRole']) as StoreMappedActions,
+    async onSubmit() {
+      try {
+        this.isLoading = true;
+        await this.revokeGameAdminRole({walletAddress: this.walletAddress, contract: this.contract});
+      } catch (e) {
+        console.error(e);
+      } finally {
+        this.walletAddress = '';
+        this.isLoading = false;
+      }
+    }
+  },
+
+});
+</script>
+
+<style scoped>
+.gap-2 {
+  gap: 0.5rem;
+}
+</style>

--- a/frontend/src/components/smart/AdminTab.vue
+++ b/frontend/src/components/smart/AdminTab.vue
@@ -66,10 +66,7 @@ export default Vue.extend({
     ...mapActions(['userHasAdminAccess', 'userHasMinterAccess']) as StoreMappedActions,
 
     async fetchData() {
-      this.hasTabAccess = await this.userHasAdminAccess({contract: this.contract});
-      if (!this.hasTabAccess && this.contract.methods.MINTER_ROLE) {
-        this.hasTabAccess = await this.userHasMinterAccess({contract: this.contract});
-      }
+      this.hasTabAccess = await this.userHasAdminAccess({contract: this.contract}) || await this.userHasMinterAccess({contract: this.contract});
     },
   },
 

--- a/frontend/src/components/smart/AdminTab.vue
+++ b/frontend/src/components/smart/AdminTab.vue
@@ -5,6 +5,7 @@
       <Hint v-if="!hasTabAccess" :text="$t('admin.doNotHaveAccessTooltip')"/>
     </template>
     <AdminMaker v-if="contract" :contract="contract"/>
+    <AdminRevoker v-if="contract" :contract="contract"/>
     <component :is="component" :contract="contract"/>
   </b-tab>
 </template>
@@ -20,6 +21,7 @@ import Hint from '@/components/Hint.vue';
 import CBKLandAdmin from '@/components/smart/CBKLandAdmin.vue';
 import WeaponsAdmin from '@/components/smart/WeaponsAdmin.vue';
 import BurningManagerAdmin from '@/components/smart/BurningManagerAdmin.vue';
+import AdminRevoker from '@/components/smart/AdminRevoker.vue';
 
 interface StoreMappedActions {
   userHasAdminAccess(payload: { contract: Contract<any> }): Promise<boolean>;
@@ -31,7 +33,7 @@ interface Data {
 }
 
 export default Vue.extend({
-  components: {Hint, AdminMaker, QuestsAdmin, CBKLandAdmin, WeaponsAdmin, BurningManagerAdmin},
+  components: {Hint, AdminMaker, AdminRevoker, QuestsAdmin, CBKLandAdmin, WeaponsAdmin, BurningManagerAdmin},
   props: {
     title: {
       type: String as PropType<string>,

--- a/frontend/src/components/smart/AdminTab.vue
+++ b/frontend/src/components/smart/AdminTab.vue
@@ -25,6 +25,8 @@ import AdminRevoker from '@/components/smart/AdminRevoker.vue';
 
 interface StoreMappedActions {
   userHasAdminAccess(payload: { contract: Contract<any> }): Promise<boolean>;
+
+  userHasMinterAccess(payload: { contract: Contract<any> }): Promise<boolean>;
 }
 
 interface Data {
@@ -61,10 +63,13 @@ export default Vue.extend({
   },
 
   methods: {
-    ...mapActions(['userHasAdminAccess']) as StoreMappedActions,
+    ...mapActions(['userHasAdminAccess', 'userHasMinterAccess']) as StoreMappedActions,
 
     async fetchData() {
       this.hasTabAccess = await this.userHasAdminAccess({contract: this.contract});
+      if (!this.hasTabAccess && this.contract.methods.MINTER_ROLE) {
+        this.hasTabAccess = await this.userHasMinterAccess({contract: this.contract});
+      }
     },
   },
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -722,7 +722,9 @@
     },
     "doNotHaveAccessTooltip": "You do not have admin access on this contract.",
     "grantRole": "Grant role",
+    "revokeRole": "Revoke role",
     "grantGameAdminRole": "Grant game admin role",
+    "revokeGameAdminRole": "Revoke game admin role",
     "pasteInValidWalletAddress": "Paste in valid wallet address"
   },
   "stake": {

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -3683,6 +3683,14 @@ export function createStore(web3: Web3) {
         await contract.methods.grantRole(gameAdminRole, walletAddress).send(defaultCallOptions(state));
       },
 
+      async revokeGameAdminRole({state}, {walletAddress, contract}) {
+        if (!contract || !state.defaultAccount || !Web3.utils.isAddress(walletAddress)) return;
+
+        const gameAdminRole = await contract.methods.GAME_ADMIN().call(defaultCallOptions(state));
+
+        await contract.methods.revokeRole(gameAdminRole, walletAddress).send(defaultCallOptions(state));
+      },
+
       async userHasAdminAccess({state}, {contract}) {
         if (!contract || !state.defaultAccount) return;
 

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -3703,7 +3703,7 @@ export function createStore(web3: Web3) {
       },
 
       async userHasMinterAccess({state}, {contract}) {
-        if (!contract || !state.defaultAccount) return;
+        if (!contract || !contract.methods.MINTER_ROLE || !state.defaultAccount) return;
 
         const minterRole = await contract.methods.MINTER_ROLE().call(defaultCallOptions(state));
 

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -3698,7 +3698,18 @@ export function createStore(web3: Web3) {
 
         const hasRole =  await contract.methods.hasRole(adminRole, state.defaultAccount).call(defaultCallOptions(state));
 
-        console.log(contract, hasRole);
+        console.log('Admin role: ',contract, hasRole);
+        return hasRole;
+      },
+
+      async userHasMinterAccess({state}, {contract}) {
+        if (!contract || !state.defaultAccount) return;
+
+        const minterRole = await contract.methods.MINTER_ROLE().call(defaultCallOptions(state));
+
+        const hasRole =  await contract.methods.hasRole(minterRole, state.defaultAccount).call(defaultCallOptions(state));
+
+        console.log('Minter role: ', contract, hasRole);
         return hasRole;
       },
 
@@ -3716,6 +3727,24 @@ export function createStore(web3: Web3) {
           CBKLand.methods.hasRole(cbkLandAdminRole, state.defaultAccount).call(defaultCallOptions(state)),
           Weapons.methods.hasRole(weaponsAdminRole, state.defaultAccount).call(defaultCallOptions(state)),
           BurningManager.methods.hasRole(burningManagerAdminRole, state.defaultAccount).call(defaultCallOptions(state)),
+        ];
+
+        for (const promise of promises) {
+          if (await promise) return true;
+        }
+        return false;
+      },
+
+      async userHasAnyMinterAccess({state}) {
+        const {Weapons, Characters} = state.contracts();
+        if (!Weapons || !Characters || !state.defaultAccount) return;
+
+        const weaponsMinerRole = await Weapons.methods.MINTER_ROLE().call(defaultCallOptions(state));
+        const charactersMinerRole = await Characters.methods.MINTER_ROLE().call(defaultCallOptions(state));
+
+        const promises: Promise<boolean>[] = [
+          Weapons.methods.hasRole(weaponsMinerRole, state.defaultAccount).call(defaultCallOptions(state)),
+          Characters.methods.hasRole(charactersMinerRole, state.defaultAccount).call(defaultCallOptions(state)),
         ];
 
         for (const promise of promises) {

--- a/frontend/src/views/Admin.vue
+++ b/frontend/src/views/Admin.vue
@@ -13,6 +13,8 @@ import AdminTab from '@/components/smart/AdminTab.vue';
 
 interface StoreMappedActions {
   userHasAnyAdminAccess(): Promise<boolean>;
+
+  userHasAnyMinterAccess(): Promise<boolean>;
 }
 
 interface Tab {
@@ -42,10 +44,10 @@ export default Vue.extend({
   },
 
   methods: {
-    ...mapActions(['userHasAnyAdminAccess']) as StoreMappedActions,
+    ...mapActions(['userHasAnyAdminAccess', 'userHasAnyMinterAccess']) as StoreMappedActions,
 
     async fetchData() {
-      this.hasAccessToAnyTab = await this.userHasAnyAdminAccess();
+      this.hasAccessToAnyTab = await this.userHasAnyAdminAccess() || await this.userHasAnyMinterAccess();
     },
   },
 


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?
![image](https://user-images.githubusercontent.com/34208222/153198895-3cdb767d-6f5e-4c7f-9712-929b26a2b958.png)

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Adds revoke admin role component for each admin tab, also fixes button disable on incorrect web3 address, in addition adds possibility for MINTER_ROLE to be able to see and interact with admin panel (for the contracts that implement MINTER_ROLE (as of right now, Characters and Weapons)