### PR TITLE
Feat/pvp  tweaks

### DIFF
--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -1044,6 +1044,22 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         return uint24(playerTraitBonus.mulu(playerPower));
     }
 
+    function getCharacterPower(uint256 characterID)
+        external
+        view
+        returns (uint24) 
+    {
+        uint8 level = characters.getLevel(characterID);
+        uint8 trait = characters.getTrait(characterID);
+        uint24 basePower = Common.getPowerAtLevel(level);
+        (
+            ,
+            int128 weaponMultFight,
+            uint24 weaponBonusPower,
+            
+        ) = weapons.getFightData(weaponID, trait);
+    }
+
     function getPVPTraitBonusAgainst(
         uint8 characterTrait,
         uint8 weaponTrait,

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -178,7 +178,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
     }
 
     function _characterNotInDuel(uint256 characterID) internal view {
-        require(!isCharacterInDuel(characterID), "In duel queue");
+        require(!isCharacterInDuel(characterID), "In queue");
     }
 
     modifier isOwnedCharacter(uint256 characterID) {
@@ -1083,7 +1083,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         int128 fightTraitBonus = game.fightTraitBonus();
         int128 charTraitFactor = ABDKMath64x64.divu(50, 100);
         if (characterTrait == weaponTrait) {
-            traitBonus = traitBonus.add(fightTraitBonus);
+            traitBonus = traitBonus.add(fightTraitBonus.mul(2));
         }
 
         // We apply 50% of char trait bonuses because they are applied twice (once per fighter)

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -1009,6 +1009,8 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         view
         returns (uint24)
     {
+        uint24 playerFightPower = getCharacterPower(character.ID);
+
         Fighter memory fighter = fighterByCharacter[character.ID];
         uint256 weaponID = fighter.weaponID;
         uint256 seed = randoms.getRandomSeedUsingHash(
@@ -1016,19 +1018,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             blockhash(block.number - 1)
         );
 
-        int128 bonusShieldStats;
-        if (fighter.useShield) {
-            // we set bonus shield stats as 0.2
-            // Note: hardcoded - copied in getCharacterPower
-            bonusShieldStats = _getShieldStats(character.ID).sub(1).mul(20).div(100);
-        }
-
-        (
-            ,
-            int128 weaponMultFight,
-            uint24 weaponBonusPower,
-            uint8 weaponTrait
-        ) = weapons.getFightData(weaponID, character.trait);
+        uint8 weaponTrait = weapons.getTrait(weaponID);
 
         int128 playerTraitBonus = getPVPTraitBonusAgainst(
             character.trait,
@@ -1036,7 +1026,6 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             opponentTrait
         );
 
-        uint24 playerFightPower = Common.getPlayerPowerBase100(character.basePower, (weaponMultFight.add(bonusShieldStats)), weaponBonusPower);
         uint256 playerPower = RandomUtil.plusMinus30PercentSeeded(
             playerFightPower,
             seed
@@ -1046,7 +1035,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
     }
 
     function getCharacterPower(uint256 characterID)
-        external
+        public
         view
         characterInArena(characterID)
         returns (uint24) 
@@ -1083,7 +1072,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         int128 fightTraitBonus = game.fightTraitBonus();
         int128 charTraitFactor = ABDKMath64x64.divu(50, 100);
         if (characterTrait == weaponTrait) {
-            traitBonus = traitBonus.add(fightTraitBonus.mul(2));
+            traitBonus = traitBonus.add(fightTraitBonus.mul(3));
         }
 
         // We apply 50% of char trait bonuses because they are applied twice (once per fighter)

--- a/frontend/src/components/smart/PvPArena.vue
+++ b/frontend/src/components/smart/PvPArena.vue
@@ -97,6 +97,7 @@ export default {
         name: '',
         level: null,
         power: null,
+        fullPower: null,
         rank: null,
         element: null,
       },
@@ -118,7 +119,8 @@ export default {
         name: '',
         level: null,
         rank: null,
-        power: null
+        power: null,
+        fullPower: null,
       },
       opponentActiveWeaponWithInformation: {
         weaponId: null,
@@ -153,6 +155,7 @@ export default {
       'getSeasonDuration',
       'getCharacterLevel',
       'getCharacterPower',
+      'getCharacterFullPower',
       'getRankingPointsByCharacter',
       'getRankingsPoolByTier',
       'getTierTopCharacters',
@@ -178,6 +181,8 @@ export default {
       this.isCharacterInArena = true;
 
       const fighter = formatFighter(await this.getFighterByCharacter(this.currentCharacterId));
+
+      this.characterInformation.fullPower = await this.getCharacterFullPower(this.currentCharacterId);
 
       this.activeWeaponWithInformation = {
         weaponId: fighter.weaponID,
@@ -227,6 +232,8 @@ export default {
 
       this.opponentInformation.power = await this.getCharacterPower(defenderId);
 
+      this.opponentInformation.fullPower = await this.getCharacterFullPower(defenderId);
+
       const fighter = formatFighter(await this.getFighterByCharacter(defenderId));
 
       this.opponentActiveWeaponWithInformation = {
@@ -249,7 +256,8 @@ export default {
         name: '',
         level: null,
         rank: null,
-        power: null
+        power: null,
+        fullPower: null
       };
 
       this.opponentActiveWeaponWithInformation = {
@@ -432,6 +440,8 @@ export default {
       if (this.isCharacterInArena) {
         const fighter = formatFighter(await this.getFighterByCharacter(this.currentCharacterId));
 
+        this.characterInformation.fullPower = await this.getCharacterFullPower(this.currentCharacterId);
+
         this.activeWeaponWithInformation = {
           weaponId: fighter.weaponID,
           information: await this.getWeaponInformation(fighter.weaponID)
@@ -552,6 +562,8 @@ export default {
 
         if (this.isCharacterInArena) {
           const fighter = formatFighter(await this.getFighterByCharacter(value));
+
+          this.characterInformation.fullPower = await this.getCharacterFullPower(value);
 
           this.activeWeaponWithInformation = {
             weaponId: fighter.weaponID,

--- a/frontend/src/components/smart/PvPArenaInfo.vue
+++ b/frontend/src/components/smart/PvPArenaInfo.vue
@@ -64,9 +64,17 @@
     </ul>
     <ul class="characterAttrsList">
       <li class="characterName">{{ characterInformation.name || '' }}</li>
-      <li>
+      <li v-if="insideArena">
         <span>
           {{$t('pvp.power')}}
+        </span>
+        <span>
+          {{ characterInformation.fullPower }}
+        </span>
+      </li>
+      <li v-else>
+        <span>
+          {{$t('pvp.basePower')}}
         </span>
         <span>
           {{ characterInformation.power }}
@@ -103,6 +111,10 @@ export default {
   },
 
   props: {
+    insideArena: {
+      type: Boolean,
+      default: false,
+    },
     tierRewardsPool: {
       default: null
     },
@@ -121,6 +133,7 @@ export default {
         name: '',
         level: null,
         power: null,
+        fullPower: null,
         rank: null,
         element: null,
       }

--- a/frontend/src/components/smart/PvPArenaMatchMaking.vue
+++ b/frontend/src/components/smart/PvPArenaMatchMaking.vue
@@ -199,6 +199,7 @@ export default {
         name: '',
         level: null,
         power: null,
+        fullPower: null,
         rank: null,
         element: null
       }
@@ -222,7 +223,8 @@ export default {
         name: '',
         level: null,
         rank: null,
-        power: null
+        power: null,
+        fullPower: null,
       }
     },
     opponentActiveWeaponWithInformation: {
@@ -370,7 +372,7 @@ export default {
       } catch (err) {
         console.log('leave arena error: ', err.message);
 
-        this.handleErrorMessage(err.message, 'Char not in arena', i18n.t('pvp.charNotInArena'));
+        this.handleErrorMessage(err.message, 'Not in arena', i18n.t('pvp.charNotInArena'));
         this.handleErrorMessage(err.message, 'Defender duel in process', i18n.t('pvp.duelInProcess'));
       }
 
@@ -394,7 +396,7 @@ export default {
         this.handleErrorMessage(err.message, 'Already in match', i18n.t('pvp.alreadyInMatch'));
         this.handleErrorMessage(err.message, 'No enemy in tier', i18n.t('pvp.noEnemyInTier'));
         this.handleErrorMessage(err.message, 'Char dueling', i18n.t('pvp.charDueling'));
-        this.handleErrorMessage(err.message, 'Char not in arena', i18n.t('pvp.charNotInArena'));
+        this.handleErrorMessage(err.message, 'Not in arena', i18n.t('pvp.charNotInArena'));
 
         this.loading = false;
         return;
@@ -447,8 +449,8 @@ export default {
 
         if (duelFinishedResult.length) {
           const formattedResult = formatDuelResult(duelFinishedResult[duelFinishedResult.length - 1].returnValues);
-          this.duelResult.defenderPower = this.opponentInformation.power;
-          this.duelResult.attackerPower = this.characterInformation.power;
+          this.duelResult.defenderPower = this.opponentInformation.fullPower;
+          this.duelResult.attackerPower = this.characterInformation.fullPower;
           this.duelResult.result = formattedResult.attackerWon ? 'win' : 'lose';
           this.duelResult.attackerRoll = formattedResult.attackerRoll;
           this.duelResult.defenderRoll = formattedResult.defenderRoll;

--- a/frontend/src/components/smart/PvPArenaMatchMaking.vue
+++ b/frontend/src/components/smart/PvPArenaMatchMaking.vue
@@ -485,7 +485,7 @@ export default {
         console.log('prepare perform duel error: ', err.message);
 
         this.handleErrorMessage(err.message, 'Decision time expired', i18n.t('pvp.decisionTimeExpired'));
-        this.handleErrorMessage(err.message, 'Char in duel queue', i18n.t('pvp.charDueling'));
+        this.handleErrorMessage(err.message, 'In queue', i18n.t('pvp.charDueling'));
         this.handleErrorMessage(err.message, 'Not in match', i18n.t('pvp.notInMatch'));
 
         this.loading = false;

--- a/frontend/src/components/smart/PvPArenaPreparation.vue
+++ b/frontend/src/components/smart/PvPArenaPreparation.vue
@@ -237,6 +237,7 @@ export default {
         name: '',
         level: null,
         power: null,
+        fullPower: null,
         rank: null,
         element: null,
       }

--- a/frontend/src/components/smart/PvPArenaSummary.vue
+++ b/frontend/src/components/smart/PvPArenaSummary.vue
@@ -61,7 +61,7 @@
                 </li>
                 <li v-for="duel in duelHistory" :key="`${duel.attackerId}-${duel.timestamp}`">
                   <span class="date">{{ dayjs(new Date(duel.timestamp * 1000)).format('YYYY/MM/DD') }}</span>
-                  <span :class="{'lost': !duel.attackerWon}" class="result">{{ duel.attackerWon ? i18n.t('pvp.win') : i18n.t('pvp.lose') }}</span>
+                  <span :class="{'lost': !duel.attackerWon}" class="result">{{ duel.attackerWon ? $t('pvp.win') : $t('pvp.lose') }}</span>
                 </li>
               </ul>
             </div>

--- a/frontend/src/components/smart/PvPArenaSummary.vue
+++ b/frontend/src/components/smart/PvPArenaSummary.vue
@@ -78,6 +78,7 @@
         :currentRankedSeason="currentRankedSeason"
         :secondsBeforeNextSeason="secondsBeforeNextSeason"
         :characterInformation="characterInformation"
+        insideArena
       />
     </div>
   </div>
@@ -121,6 +122,7 @@ export default {
         name: '',
         level: null,
         power: null,
+        fullPower: null,
         rank: null,
         element: null,
       }
@@ -193,7 +195,7 @@ export default {
       } catch (err) {
         console.log('leave arena error: ', err.message);
 
-        this.handleErrorMessage(err.message, 'Char not in arena', i18n.t('pvp.charNotInArena'));
+        this.handleErrorMessage(err.message, 'Not in arena', i18n.t('pvp.charNotInArena'));
         this.handleErrorMessage(err.message, 'Defender duel in process', i18n.t('pvp.duelInProcess'));
       } finally {
         this.loading = false;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1048,6 +1048,7 @@
     "currentSeason": "Current Season",
     "restartsIn": "Restarts In",
     "days": "days",
+    "basePower": "Base Power",
     "power": "Power",
     "currentRank": "Ranking points",
     "clickToClaim": "Here you can claim your rewards",

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -5217,6 +5217,15 @@ export function createStore(web3: Web3) {
         return characterPower;
       },
 
+      async getCharacterFullPower({ state }, characterId) {
+        const { PvpArena } = state.contracts();
+        if (!PvpArena || !state.defaultAccount) return;
+
+        const characterFullPower = await PvpArena.methods.getCharacterPower(characterId).call({ from: state.defaultAccount });
+
+        return characterFullPower;
+      },
+
       async getRankingPointsByCharacter({ state }, characterId) {
         const { PvpArena } = state.contracts();
         if (!PvpArena || !state.defaultAccount) return;

--- a/test/pvp-arena.js
+++ b/test/pvp-arena.js
@@ -1245,7 +1245,7 @@ contract("PvpArena", (accounts) => {
 
         await expectRevert(
           pvpArena.prepareDuel(character1ID, { from: accounts[1] }),
-          "In duel queue"
+          "In queue"
         );
       });
     });

--- a/test/pvp-arena.js
+++ b/test/pvp-arena.js
@@ -710,7 +710,7 @@ contract("PvpArena", (accounts) => {
       it("should revert", async () => {
         await expectRevert(
           pvpArena.findOpponent(character1ID, { from: accounts[1] }),
-          "Char not in arena"
+          "Not in arena"
         );
       });
     });


### PR DESCRIPTION
This PR:
- Adds a function in PvpArena.sol to get a character's full power (includes weapon's and shield's influence on the equation, excludes trait bonus).
- Displays full power in the front-end when inside the arena (weapon/shield already assigned to character).
- Multiplies trait bonus by 2, since PvP power roll volatility was increased.
- Fixes duel history not showing.
- Shortens some require-messages to reduce contract size.