### PR TITLE
Add discard support to NFTMarket

### DIFF
--- a/contracts/NFTMarket.sol
+++ b/contracts/NFTMarket.sol
@@ -645,6 +645,7 @@ contract NFTMarket is
         while(typeCount > 0) {
             IERC721 tokenAddress = IERC721(listedTokenTypes.at(typeCount - 1));
             discardedCount += discardSellerListingsOfToken(_seller, tokenAddress);
+            --typeCount;
         }
     }
 

--- a/contracts/NFTMarket.sol
+++ b/contracts/NFTMarket.sol
@@ -593,7 +593,13 @@ contract NFTMarket is
 
         _updateListedTokenTypes(_tokenAddress);
 
-        _tokenAddress.safeTransferFrom(address(this), address(0), _id);
+        uint256[] memory burnIds = new uint256[](1);
+        burnIds[0] = _id;
+        if(address(_tokenAddress) == address(weapons)) {
+            weapons.burnWithoutDust(burnIds);
+        } else {
+            revert('Unsupported token for burning');
+        }
 
         emit DiscardedListing(seller, _tokenAddress, _id);
     }

--- a/contracts/NFTMarket.sol
+++ b/contracts/NFTMarket.sol
@@ -595,7 +595,9 @@ contract NFTMarket is
 
         uint256[] memory burnIds = new uint256[](1);
         burnIds[0] = _id;
-        if(address(_tokenAddress) == address(weapons)) {
+        if(address(_tokenAddress) == address(characters)) {
+            characters.burnWithoutSoul(burnIds);
+        } else if(address(_tokenAddress) == address(weapons)) {
             weapons.burnWithoutDust(burnIds);
         } else {
             revert('Unsupported token for burning');

--- a/contracts/NFTMarket.sol
+++ b/contracts/NFTMarket.sol
@@ -604,7 +604,6 @@ contract NFTMarket is
     {
         EnumerableSet.UintSet storage listedTokens = listedTokenIDs[address(_tokenAddress)];
 
-        uint256 index = 0;
         uint256 stop = start + length;
         if(stop > listedTokens.length())
             stop = listedTokens.length();

--- a/contracts/characters.sol
+++ b/contracts/characters.sol
@@ -300,6 +300,18 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
         }
     }
 
+    function burnWithoutSoul(uint256[] memory burnIDs) public restricted {
+        for(uint256 i = 0; i < burnIDs.length; i++) {
+            _burnWithoutSoul(burnIDs[i]);
+        }
+    }
+
+    function _burnWithoutSoul(uint256 burnID) internal {
+        address burnOwner = ownerOf(burnID);
+        _burn(burnID);
+        emit Burned(burnOwner, burnID);
+    }
+
     function upgradeWithSoul(uint256 targetCharId, uint256 soulAmount) external restricted {
         uint256 burnPower = soulAmount.mul(10);
         require(uint(4).mul(getPowerAtLevel(tokens[targetCharId].level)) >= getTotalPower(targetCharId).add(burnPower), "Power limit");


### PR DESCRIPTION
As discussed in Discord, this change adds support for automatically removing listed items when and address is marked banned.

To support discarding historical items and high volume addresses, intermediate `slice` functions are made available as well.

While some of these function are reasonable for an end user to use on owned accounts, all methods are currently `restricted` for now.

Note:
With this change the Character contract size is 23.98KB.  If we want, we can defer the support for characters in `discardListing()` until other changes have a chance to shrink the contract to give more breathing room.

Testing:
- Compiles and deploys locally.
- add admin and minion accounts to metamask
- build and deploy contracts
- metamask: transfer 100 skill from admin to minion
- game UI: recruit a character on minion
- game UI: forge weapon x10 on minion
- game UI: forge weapon x10 on minion
- game UI: fight once on minion (workaround for `noFreshLookup`)
- python script: minion invokes `NFTMarket.addListing()` for all 1 star weapons
- python script: verify weapons on market via `NFTMarket.getListingIDs(<Weapons>)`
- python script: admin invokes `NFTMarket.discardListing(<Characters>, 100)`
  => `Revert reason: Token ID not listed`
- python script: admin grants `GAME_ADMIN` role for self to Weapons
- python script: admin grants `GAME_ADMIN` role for NFTMarket to Weapons
- python script: admin invokes `NFTMarket.discardListing(<Weapons>, 20)`
  => completed
  => confirm `DiscardedListing` event is sent and contains correct parameters
  => confirm weapon no longer on NFT Market
  => confirm `Weapons.ownerOf(20)` throws an exception (no owner after burned)
- python script: admin invokes `NFTMarket.setUserBan(<minion>, true)`
  => completed
  => confirm NFTMarket is now empty of weapons