### PR TITLE
Increase memory for 'npm run build:frontend'

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,8 @@ jobs:
         run: npm run build -- --all
 
       - run: npm run build:frontend
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Deploy testnet frontend
         uses: netlify/actions/cli@6c34c3fcafc69ac2e1d6dbf226560329c6dfc51b


### PR DESCRIPTION
More than half of the most recent `npm run build:frontend` atempts have failed due to out of memory issues.

This change increases the memory setting from 512MB to 8GB which seems to be sufficient.