### PR TITLE
Add VAR_PARAM_ORACLE_FIXED_PRICE to game contract

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -49,6 +49,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     uint256 public constant VAR_PARAM_HOURLY_MAX_POWER_PERCENT = 16;
     uint256 public constant VAR_PARAM_SIGNIFICANT_HOUR_FIGHTS = 17;
     uint256 public constant VAR_PARAM_HOURLY_PAY_ALLOWANCE = 18;
+    uint256 public constant VAR_PARAM_ORACLE_FIXED_PRICE = 19;
 
     // Mapped user variable(userVars[]) keys, one value per wallet
     uint256 public constant USERVAR_DAILY_CLAIMED_AMOUNT = 10001;
@@ -850,7 +851,11 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     }
 
     function usdToSkill(int128 usdAmount) public view returns (uint256) {
-        return usdAmount.mulu(priceOracleSkillPerUsd.currentPrice());
+        uint256 oraclePrice = vars[VAR_PARAM_ORACLE_FIXED_PRICE];
+        if(oraclePrice == 0) {
+            oraclePrice = priceOracleSkillPerUsd.currentPrice();
+        }
+        return usdAmount.mulu(oraclePrice);
     }
 
     function claimTokenRewards() public {
@@ -993,5 +998,4 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
     function getOwnRewardsClaimTax() public view returns (int128) {
         return _getRewardsClaimTax(msg.sender);
     }
-
 }

--- a/migrations/139_SetVarsSkillOracleFixed.js
+++ b/migrations/139_SetVarsSkillOracleFixed.js
@@ -1,0 +1,23 @@
+const BasicPriceOracle = artifacts.require("BasicPriceOracle");
+const CryptoBlades = artifacts.require("CryptoBlades");
+
+module.exports = async function (deployer, network) {
+    const game = await CryptoBlades.deployed();
+    const priceOracle = await BasicPriceOracle.deployed();
+
+    // BasicPriceOracle points to KING instead of SKILL after migration 92,
+    // on local.  I'm not clear why mainnets don't seem to have this issue.
+    //
+    // The following logic retrieves the SKILL oracle from the game contract
+    // and updates the priceOracle variable's addresses.
+    const skillPriceOracleAddress = await game.priceOracleSkillPerUsd();
+    priceOracle.address = skillPriceOracleAddress;
+    priceOracle.contract._address = skillPriceOracleAddress;
+
+    // Find the price reported by the SKILL oracle.
+    const currentPrice = await priceOracle.currentPrice();
+
+    // Store the price in vars[VAR_PARAM_ORACLE_FIXED_PRICE].
+    const paramOracleFixedPrice = await game.VAR_PARAM_ORACLE_FIXED_PRICE();
+    await game.setVar(paramOracleFixedPrice, currentPrice);
+};


### PR DESCRIPTION
This change does the following with the game contract:
- adds `VAR_PARAM_ORACLE_FIXED_PRICE` constant
- updates `usdToSkill` to use `vars[VAR_PARAM_ORACLE_FIXED_PRICE]` when non-zero
- populates `vars[VAR_PARAM_ORACLE_FIXED_PRICE]` with the `currentPrice()` from the SKILL BasicPriceOracle

### Purpose

This change lowers the gas use by the following methods in the game contract:
- `_payContract()`
- `_payPlayer()`
- `mintCharacter()`
- `mintWeapon()`
- `mintWeaponN()`
- `mintWeaponNUsingStakedSkill()`
- `mintWeaponUsingStakedSkill()`

### Testing

_Basic_
- Found that BasicPriceOracle (in `build/contracts/BasicPriceOracle.json`) has the KING oracle address instead of the SKILL oracle address.
- Added logic to the new migration to ensure usage of the SKILL BasicPriceOracle is used
- Verified that the migration works properly.
- Verified that `CryptoBlades.usdToSkill()` works correctly.
- Verified that `mintCharacter()`, `mintWeapon()`, and `mintWeaponN()` work correctly.

_Extended_
- Mint 4 characters.
- Send all plaza characters to garrison.
- Ensure 16 skill (for 8 characters x 4) in wallet.
- Ensure no unclaimed skill in wallet (to avoid triggering different code paths).
- Ensure `vars[VAR_PARAM_ORACLE_FIXED_PRICE]` is set to zero.
- Invoke `CryptoBlades.mintCharacter()` four times (via game UI or contract directly), making note of the `gasUsed`.
- Send all plaza characters to garrison.
- Apply the migration file.
- Ensure `vars[VAR_PARAM_ORACLE_FIXED_PRICE]` has the same value as `CryptoBlades.priceOracleSkillPerUsd.currentPrice()`.
- Invoke `CryptoBlades.mintCharacter()` four times (via game UI or contract directly), making note of the `gasUsed`.
- Gas used for the 4 character mints:
  - invoke BasicPriceOracle:
    - `332370`
    - `317370`
    - `317370`
    - `317370`
  - use `vars[VAR_PARAM_ORACLE_FIXED_PRICE]`:
    - `315273`
    - `303144`
    - `303144`
    - `303144`
  - difference:
    - `-17097 (-5.14%)`
    - `-14226 (-4.48%)`
    - `-14226 (-4.48%)`
    - `-14226 (-4.48%)`
