### PR TITLE
Add transfer UI for Junk, KeyLootBox, RaidTrinket, Shield

### DIFF
--- a/frontend/src/components/smart/NftList.vue
+++ b/frontend/src/components/smart/NftList.vue
@@ -281,7 +281,7 @@
           @click="onNftClick(nft.type, nft.id)"
           @contextmenu="canFavorite && toggleFavorite($event, nft.type, nft.id)"
         >
-          <nft-options-dropdown v-if="showNftOptions" :nftType="nft.type" :nftId="nft.id" :options="options" class="nft-options"/>
+          <nft-options-dropdown v-if="showNftOptions" :nftType="nft.type" :nftId="nft.id" :options="options" :showTransfer="!isMarket" class="nft-options"/>
           <nft-icon :favorite="isFavorite(nft.type, nft.id)" :nft="nft" :isShop="isShop"/>
           <div class="above-wrapper" v-if="$slots.above || $scopedSlots.above">
             <slot name="above" :nft="nft"></slot>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -5102,8 +5102,8 @@ export function createStore(web3: Web3) {
         }
       },
       async transferNFT({ state, dispatch },{nftId, receiverAddress, nftType}: {nftId: number, receiverAddress: string, nftType: string}) {
-        const { Characters, Weapons } = state.contracts();
-        if (!Characters || !Weapons || !state.defaultAccount) return;
+        const { Characters, Junk, KeyLootbox, RaidTrinket, Shields, Weapons } = state.contracts();
+        if (!Characters || !Junk || !KeyLootbox || !RaidTrinket || !Shields || !Weapons || !state.defaultAccount) return;
 
         if (nftType === 'character') {
           await Characters.methods
@@ -5112,6 +5112,38 @@ export function createStore(web3: Web3) {
               from: state.defaultAccount,
             });
           await dispatch('updateCharacterIds');
+        }
+        else if (nftType === 'junk') {
+          await Junk.methods
+            .safeTransferFrom(state.defaultAccount, receiverAddress, nftId)
+            .send({
+              from: state.defaultAccount,
+            });
+          await dispatch('updateJunkIds');
+        }
+        else if (nftType === 'keybox') {
+          await KeyLootbox.methods
+            .safeTransferFrom(state.defaultAccount, receiverAddress, nftId)
+            .send({
+              from: state.defaultAccount,
+            });
+          await dispatch('updateKeyLootboxIds');
+        }
+        else if (nftType === 'shield') {
+          await Shields.methods
+            .safeTransferFrom(state.defaultAccount, receiverAddress, nftId)
+            .send({
+              from: state.defaultAccount,
+            });
+          await dispatch('updateShieldIds');
+        }
+        else if (nftType === 'trinket') {
+          await RaidTrinket.methods
+            .safeTransferFrom(state.defaultAccount, receiverAddress, nftId)
+            .send({
+              from: state.defaultAccount,
+            });
+          await dispatch('updateTrinketIds');
         }
         else if (nftType === 'weapon') {
           await Weapons.methods

--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -371,7 +371,7 @@
             <div class="d-flex justify-content-space-between">
               <h1>{{$t('equipment')}} ({{ nftsCount }})</h1>
             </div>
-            <nft-list v-if="nftsCount > 0" v-model="selectedNft"/>
+            <nft-list :showNftOptions="true" v-if="nftsCount > 0" v-model="selectedNft"/>
           </div>
         </div>
       </b-tab>


### PR DESCRIPTION
This change adds the `...` dropdown with the `Transfer` option for Junk (CBJ), KeyLootbox (CBKBX), RaidTrinket (CBT), and Shield (CBS) in the Equipment tab of the Blacksmith page.  The behavior matches the offering for Weapon (CBW) on the Weapons tab of the Blacksmith page.

No contract changes were needed, as the support was already available.  Chains other than OEC have been able to use this functionality via the various chain explorers in the browser.

### Screenshots
The button and menu:
![image](https://user-images.githubusercontent.com/36871683/157165444-9073d58f-241a-4955-b98a-3a66faf65850.png)

The recipient address popup:
![image](https://user-images.githubusercontent.com/36871683/157165470-4a3272f0-5e42-406a-87a9-14d3913421bd.png)


### Testing

The flow of testing is the same for all four cases, except for the acquisition step:

1. Acquisition (direct contract calls from `GAME_ADMIN` account)
  - Junk
    - `Junk.mint(<address>, 4)`
  - KeyLootbox
    - `KeyLootbox.mint(<address>)`
  - RaidTrinket
    - `RaidTrinket.mint(<address>, 4, 0)`
  - Shield
    - `CryptoBlades.purchaseShield()`
2. Transfer via the game UI
  - Click on `Blacksmith`
  - Click on `Equipment`
  - Click `...` on the NFT
  - Select `Transfer` from the menu
  - Enter the recipient address
  - Click `Transfer!`
  - Confirm in Metamask
  - Observe NFT disappears
3. Receive
  - Switch to the recipient account in Metamask
  - Refresh and click on `Equipment` again
  - Observe NFT arrived
