### PR TITLE
Add over-pay protection to incrementQuestProgress()

### DIFF
--- a/contracts/SimpleQuests.sol
+++ b/contracts/SimpleQuests.sol
@@ -359,8 +359,9 @@ contract SimpleQuests is Initializable, AccessControlUpgradeable {
     }
 
     function incrementQuestProgress(uint256 characterID, uint256 questID, uint256 progress) private {
-        uint currentProgress = characters.getNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS);
-        characters.setNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS, currentProgress + progress);
+        uint totalProgress = characters.getNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS) + progress;
+        require(totalProgress <= quests[characterQuest[characterID]].requirementAmount, "Too much");
+        characters.setNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS, totalProgress);
         emit QuestProgressed(questID, characterID);
     }
 


### PR DESCRIPTION
When submitting NFTs or amounts, the contract does not protect against overpayment.  While the game UI tries to guide the user away from overpaying for a quest, it can still happen due to quick clicking or with slow responsiveness chains.

This chain adds a check for overpayment and report "Too much" as the revert reason when attempting to pay too much.

### Screenshots

Metamask hint when attempting to over-pay:
![image](https://user-images.githubusercontent.com/36871683/157190129-61529c98-0f18-40fa-8016-22cb3c1d640d.png)

Sample output from Ganache log when attempting on local:
![image](https://user-images.githubusercontent.com/36871683/157190251-8bf5165b-eaea-4a1d-9c7c-1b3871e43031.png)

### Testing

Using a lesser dust (2 required amount) quest:
1. Attempt to submit 3 or more
=> fail with "Too much"
2. Submit 1, then submit 2 or more
=> fail with "Too much"
3. Submit 1, then submit 1
=> succeed
4. Submit 2
=> succeed