### PR TITLE
Add Garrison.transferFromGarrison()

### DIFF
--- a/contracts/Garrison.sol
+++ b/contracts/Garrison.sol
@@ -122,6 +122,17 @@ contract Garrison is Initializable, IERC721ReceiverUpgradeable, AccessControlUpg
       restoreFromGarrison(garrisonId);
     }
 
+    function transferFromGarrison(address receiver, uint256 id)
+        public
+        isCharacterOwner(id)
+        isInGarrison(id)
+    {
+        delete characterOwner[id];
+        userGarrison[msg.sender].remove(id);
+        allCharactersInGarrison.remove(id);
+        characters.safeTransferFrom(address(this), receiver, id);
+    }
+
     function claimAllXp(uint256[] calldata chars) external isCharactersOwner(chars) {
         uint256[] memory xps = game.getXpRewards(chars);
         game.resetXp(chars);


### PR DESCRIPTION
When transferring a character from garrison, it's cumbersome and expensive:
1. `approve(<Garrison>, <a>)`
2. `swapWithGarrison(<a>, <b>)`
3. `safeTransferFrom(<b>)`
4. `restoreFromGarrison(<a>)`

If doing multiple transfers, this can be optimized:
1. `setApproveForAll(<Garrison>, true)`
2. `sendToGarrison(<a>)`
3. `restoreFromGarrison(<b>)`
4. `safeTransferFrom(<b>)`
5. repeat steps 3-4 for different values of `<b>`
6. `restoreFromGarrison(<a>)`

This change simplifies the above by introducing `Garrison.transferFromGarrison()` as a single transaction.

### Testing

1. `Garrison.transferFromGarrison(<receiver>, <id>)` from non-owner
=> failed
2. `Garrison.transferFromGarrison(<receiver>, <id>)` for plaza character
=> failed
3. `Garrison.transferFromGarrison(<receiver>, <id>)` for owned garrison character
=> success

For the success gas, the `gasUsed` in the transaction receipt on local is `94578`.

The Garrison contract size with this change (as reported by `npx truffle run contract-size`) is `6.63 KiB`.