### PR TITLE
incrementQuestProgress() automatically invokes generateRewardQuestSeed()

### DIFF
--- a/contracts/SimpleQuests.sol
+++ b/contracts/SimpleQuests.sol
@@ -362,6 +362,9 @@ contract SimpleQuests is Initializable, AccessControlUpgradeable {
         uint currentProgress = characters.getNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS);
         characters.setNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS, currentProgress + progress);
         emit QuestProgressed(questID, characterID);
+        if (quests[characterQuest[characterID]].requirementAmount <= currentProgress + progress) {
+            generateRewardQuestSeed(characterID);
+        }
     }
 
     // VIEWS


### PR DESCRIPTION
When submitting -- either amounts or NFTs -- the `incrementQuestProgress()` function is used to record the quest progress.

This change invokes `generateRewardQuestSeed()` automatically when the quest requirement amount is met, removing the need for the user to confirm (and pay for) an additional transaction.

Note: This change does not improve (or even affect) the `RAID` quest type.

### Screenshots

The `GENERATE REWARD QUEST SEED` version of this confirmation is now unnecessary (for non-`RAID` types):
![image](https://user-images.githubusercontent.com/36871683/157203314-de5a1a88-13cc-488b-bd28-050dea473e81.png)

### Testing

Completed about a dozen quests (a mixture of amount and NFT requirements) to confirm that the `GENERATE` confirmation is never offered by Metamask and that the quests complete properly.

No testing done for `RAID` type.