### PR TITLE
Add self-transfer prevention to transferSoul()

### DIFF
--- a/contracts/BurningManager.sol
+++ b/contracts/BurningManager.sol
@@ -149,6 +149,7 @@ contract BurningManager is Initializable, AccessControlUpgradeable {
     }
 
     function transferSoul(address targetAddress, uint256 soulAmount) public {
+        require(msg.sender != targetAddress);
         userVars[msg.sender][USERVAR_SOUL_SUPPLY] = userVars[msg.sender][USERVAR_SOUL_SUPPLY].sub(soulAmount);
         userVars[targetAddress][USERVAR_SOUL_SUPPLY] = userVars[targetAddress][USERVAR_SOUL_SUPPLY].add(soulAmount);
     }


### PR DESCRIPTION
While testing the soul transfer UI, I found that the BurningManager contract allows transfer-to-self (which is a no-op).

It seems like that should be reported as an error.

Adding the appropriate `require` triggers an exception in Metamask gas estimation, avoiding wasting the user's gas money.

### Testing

Tested with the soul burn UI, both the success and failure cases.