### PR TITLE
Add UI for transferFromGarrison() method

### DIFF
--- a/frontend/src/components/smart/CharacterList.vue
+++ b/frontend/src/components/smart/CharacterList.vue
@@ -55,7 +55,7 @@
         </div>
         <slot name="sold" :character="c"></slot>
         <nft-options-dropdown v-if="showNftOptions" :nftType="'character'" :nftId="c.id" :options="options"
-          :showTransfer="!isMarket && !isGarrison" class="nft-options"/>
+          :showTransfer="!isMarket" class="nft-options"/>
         <div class="art" >
           <div class="animation" />
           <CharacterArt :class="[showCosmetics ? 'character-cosmetic-applied-' + getCharacterCosmetic(c.id) : '']"

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -5144,15 +5144,24 @@ export function createStore(web3: Web3) {
         }
       },
       async transferNFT({ state, dispatch },{nftId, receiverAddress, nftType}: {nftId: number, receiverAddress: string, nftType: string}) {
-        const { Characters, Junk, KeyLootbox, RaidTrinket, Shields, Weapons } = state.contracts();
-        if (!Characters || !Junk || !KeyLootbox || !RaidTrinket || !Shields || !Weapons || !state.defaultAccount) return;
+        const { Characters, Garrison, Junk, KeyLootbox, RaidTrinket, Shields, Weapons } = state.contracts();
+        if (!Characters || !Garrison || !Junk || !KeyLootbox || !RaidTrinket || !Shields || !Weapons || !state.defaultAccount) return;
 
         if (nftType === 'character') {
-          await Characters.methods
-            .safeTransferFrom(state.defaultAccount, receiverAddress, nftId)
-            .send({
-              from: state.defaultAccount,
-            });
+          if (state.ownedGarrisonCharacterIds.includes(nftId)) {
+            await Garrison.methods
+              .transferFromGarrison(receiverAddress, nftId)
+              .send({
+                from: state.defaultAccount,
+              });
+          }
+          else {
+            await Characters.methods
+              .safeTransferFrom(state.defaultAccount, receiverAddress, nftId)
+              .send({
+                from: state.defaultAccount,
+              });
+          }
           await dispatch('updateCharacterIds');
         }
         else if (nftType === 'junk') {


### PR DESCRIPTION
This adds UI support for the `Garrison.transferFromGarrison()` method.

### Screenshots

1. The `Transfer` menu item now available in the Garrison:
![image](https://user-images.githubusercontent.com/36871683/157645799-0de0635b-4b61-4ca0-afc7-ec9f90fb4617.png)

2. The existing plaza site working properly:
![image](https://user-images.githubusercontent.com/36871683/157645888-bf7bcd7f-1c52-4f23-9dba-392949fa3fde.png)

3. The new garrison site working properly:
![image](https://user-images.githubusercontent.com/36871683/157646011-a8196557-38fc-4840-98f1-c225118a6e76.png)

Note that `0x7ebcd57c` is `transferFromGarrison(address,uint256)`.

### Testing

- Existing plaza Transfer menu item displays and works properly.
- New garrison Transfer menu item displays and works properly.
- Transferring using either method works (character moves to `receiverAddress`).