### PR TITLE
Audit and fix approval logic in store.ts

### DIFF
--- a/frontend/src/store/bridge/index.ts
+++ b/frontend/src/store/bridge/index.ts
@@ -4,7 +4,7 @@ import {
 } from '@/interfaces';
 import {Dispatch} from 'vuex';
 import {NftTransfer, TransferedNft} from '@/interfaces/Nft';
-import {approveFeeFromAnyContractSimple} from '@/contract-call-utils';
+import {approveFeeWalletOnly} from '@/contract-call-utils';
 import BigNumber from 'bignumber.js';
 
 const defaultCallOptions = (rootState:  IState) => ({ from: rootState.defaultAccount });
@@ -88,7 +88,7 @@ const bridge = {
     { nftContractAddr: string, tokenId: number, targetChain: string, bridgeFee: string }) {
       const { NFTStorage, CryptoBlades, SkillToken } = rootState.contracts();
       if (!NFTStorage || !CryptoBlades || !SkillToken || !rootState.defaultAccount) return;
-      await approveFeeFromAnyContractSimple(
+      await approveFeeWalletOnly(
         CryptoBlades,
         SkillToken,
         rootState.defaultAccount,

--- a/frontend/src/store/merchandise/index.ts
+++ b/frontend/src/store/merchandise/index.ts
@@ -1,7 +1,7 @@
 import {
   IState,
 } from '@/interfaces';
-import {approveFeeFromAnyContractSimple} from '@/contract-call-utils';
+import {approveFeeWalletOnly} from '@/contract-call-utils';
 import {abi as priceOracleAbi} from '@/../../build/contracts/IPriceOracle.json';
 import {CartEntry} from '@/components/smart/VariantChoiceModal.vue';
 import BigNumber from 'bignumber.js';
@@ -62,7 +62,7 @@ const merchandise = {
         .getSkillNeededFromUserWallet(rootState.defaultAccount, payingAmount, true)
         .call(defaultCallOptions(rootState));
 
-      await approveFeeFromAnyContractSimple(
+      await approveFeeWalletOnly(
         CryptoBlades,
         SkillToken,
         rootState.defaultAccount,

--- a/frontend/src/store/pvp/index.ts
+++ b/frontend/src/store/pvp/index.ts
@@ -1,6 +1,6 @@
 import {IState} from '@/interfaces';
 import {Dispatch, Commit} from 'vuex';
-import {approveFeeFromAnyContractSimple} from '@/contract-call-utils';
+import {approveFeeWalletOnly} from '@/contract-call-utils';
 import BigNumber from 'bignumber.js';
 import { getGasPrice } from '../store';
 
@@ -330,7 +330,7 @@ const pvp = {
       const { PvpCore, SkillToken } = rootState.contracts();
       if (!PvpCore || !SkillToken || !rootState.defaultAccount) return;
 
-      return await approveFeeFromAnyContractSimple(
+      return await approveFeeWalletOnly(
         PvpCore,
         SkillToken,
         rootState.defaultAccount,


### PR DESCRIPTION
Users have reported issues with the approval logic failing -- and requiring "surrogate approval" workarounds -- to request the proper approval amounts.

This appears to be caused by improperly accounting for in-game-only (IGO) balances for some contract methods that do not support such balances.

An additional discovery was that many of the frontend approval operations were not accounting for rewards balances when they should have been.  This means requesting more approval than needed or requesting approval when it's unnecessary.

This change does the following:
- renames some of the approval functions for readability and brevity
- adds some new approval functions for convenience and readability
- updates the approval functions used for many operations in store.ts

The approval for these methods now accounts for rewards:
- bridgeItem
- burnCharactersIntoCharacter
- burnCharactersIntoSoul
- createOrder
- orderSpecialWeaponWithSkill
- purchaseCharacterCosmetic
- purchaseCharacterEarthTraitChange
- purchaseCharacterFireTraitChange
- purchaseCharacterLightningTraitChange
- purchaseCharacterWaterTraitChange
- purchaseRenameTag
- purchaseRenameTagDeal
- purchaseShield
- purchaseWeaponCosmetic
- purchaseWeaponRenameTag
- purchaseWeaponRenameTagDeal

The approval for these methods no longer (improperly) accounts for IGO:
- burnWeapons
- joinRaid
- reforgeWeapon
- reforgeWeaponWithDust