### PR TITLE
PvpArena contract size

### DIFF
--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -906,40 +906,22 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             matchableCharacters.length() - 1,
             seed
         );
-        uint256 opponentID;
+        uint256 opponentID = uint256(-1);
         uint256 matchableCharactersCount = matchableCharacters.length();
-        bool foundOpponent = false;
 
         for (uint256 i = 0; i < matchableCharactersCount; i++) {
             uint256 index = (randomIndex + i) % matchableCharactersCount;
             uint256 candidateID = matchableCharacters.at(index);
 
-            if (candidateID == characterID) {
-                if (matchableCharactersCount == 1) {
-                    break;
-                }
-                if (
-                    matchableCharacters.at(matchableCharactersCount - 1) ==
-                    candidateID
-                ) {
-                    candidateID = matchableCharacters.at(0);
-                } else {
-                    candidateID = matchableCharacters.at(index + 1);
-                }
-            }
-            if (
-                characters.ownerOf(candidateID) ==
-                msg.sender
-            ) {
-                continue;
-            }
+            if ((candidateID != characterID) &&
+                (characters.ownerOf(candidateID) != msg.sender)) {
 
-            foundOpponent = true;
-            opponentID = candidateID;
-            break;
+                opponentID = candidateID;
+                break;
+            }
         }
 
-        require(foundOpponent, "NE");
+        require(opponentID != uint256(-1), "NE");
 
         matchByFinder[characterID] = Match(
             characterID,

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -939,13 +939,11 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         uint8 position,
         uint256 pool
     ) private {
-        uint256 percentage = prizePercentages[position];
-        uint256 amountToTransfer = (pool.mul(percentage)).div(100);
         address playerToTransfer = characters.ownerOf(characterID);
 
         _rankingRewardsByPlayer[playerToTransfer] = _rankingRewardsByPlayer[
             playerToTransfer
-        ].add(amountToTransfer);
+        ].add((pool.mul(prizePercentages[position])).div(100));
     }
 
     /// @dev removes a character from arena and clears it's matches

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -845,8 +845,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
 
     /// @dev gets the arena tier of a character (tiers are 1-10, 11-20, etc...)
     function getArenaTier(uint256 characterID) public view returns (uint8) {
-        uint8 level = characters.getLevel(characterID);
-        return getArenaTierForLevel(level);
+        return getArenaTierForLevel(characters.getLevel(characterID));
     }
 
     function getArenaTierForLevel(uint8 level) public pure returns (uint8) {

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -982,25 +982,21 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         view
         returns (uint24)
     {
-        uint24 playerFightPower = getCharacterPower(character.ID);
-
-        Fighter memory fighter = fighterByCharacter[character.ID];
-        uint256 weaponID = fighter.weaponID;
         uint256 seed = randoms.getRandomSeedUsingHash(
             characters.ownerOf(character.ID),
             blockhash(block.number - 1)
         );
 
-        uint8 weaponTrait = weapons.getTrait(weaponID);
-
         int128 playerTraitBonus = getPVPTraitBonusAgainst(
             character.trait,
-            weaponTrait,
+            weapons.getTrait(
+                fighterByCharacter[character.ID].weaponID
+            ),
             opponentTrait
         );
 
         uint256 playerPower = RandomUtil.plusMinus30PercentSeeded(
-            playerFightPower,
+            getCharacterPower(character.ID),
             seed
         );
 

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -1009,8 +1009,6 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         characterInArena(characterID)
         returns (uint24) 
     {
-        int128 bonusShieldStats;
-        
         (
             ,
             int128 weaponMultFight,
@@ -1018,6 +1016,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
             
         ) = weapons.getFightData(fighterByCharacter[characterID].weaponID, characters.getTrait(characterID));
 
+        int128 bonusShieldStats;
         if (fighterByCharacter[characterID].useShield) {
             // we set bonus shield stats as 0.2
             // Note: hardcoded - copied in _getCharacterPowerRoll

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -1061,9 +1061,10 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         view
         returns (int128)
     {
-        uint8 trait = characters.getTrait(characterID);
-        uint256 shieldID = fighterByCharacter[characterID].shieldID;
-        int128 shieldMultFight = shields.getDefenseMultiplierForTrait(shieldID, trait);
+        int128 shieldMultFight = shields.getDefenseMultiplierForTrait(
+            fighterByCharacter[characterID].shieldID,
+            characters.getTrait(characterID)
+        );
         return (shieldMultFight);
     }
 

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -861,23 +861,19 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
     function getTierTopCharacters(uint8 tier)
         public
         view
-        returns (uint256[] memory)
+        returns (uint256[] memory topRankers)
     {
-        uint256 arrayLength;
+        uint256 arrayLength = _topRankingCharactersByTier[tier].length;
         // we return only the top 3 players, returning the array without the pivot ranker if it exists
         if (
             _topRankingCharactersByTier[tier].length == _maxTopCharactersPerTier
         ) {
-            arrayLength = _topRankingCharactersByTier[tier].length - 1;
-        } else {
-            arrayLength = _topRankingCharactersByTier[tier].length;
+            arrayLength -= 1;
         }
-        uint256[] memory topRankers = new uint256[](arrayLength);
+        topRankers = new uint256[](arrayLength);
         for (uint256 i = 0; i < arrayLength; i++) {
             topRankers[i] = _topRankingCharactersByTier[tier][i];
         }
-
-        return topRankers;
     }
 
     /// @dev returns ranked prize percentages distribution

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -831,11 +831,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
 
     /// @dev gets the amount of SKILL that is risked per duel
     function getDuelCost(uint256 characterID) public view returns (uint256) {
-        int128 tierExtra = ABDKMath64x64
-            .divu(getArenaTier(characterID).mul(100), 100)
-            .mul(_tierWagerUSD);
-
-        return game.usdToSkill(_baseWagerUSD.add(tierExtra));
+        return getDuelCostByTier(getArenaTier(characterID));
     }
 
     /// @dev gets the amount of SKILL that is risked per duel by tier

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -876,11 +876,6 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         }
     }
 
-    /// @dev returns ranked prize percentages distribution
-    function getPrizePercentages() external view returns (uint256[] memory) {
-        return prizePercentages;
-    }
-
     /// @dev returns the account's ranking prize pool earnings
     function getPlayerPrizePoolRewards() public view returns (uint256) {
         return _rankingRewardsByPlayer[msg.sender];

--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -967,9 +967,7 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
         delete fighterByCharacter[characterID];
         delete matchByFinder[characterID];
 
-        if (_matchableCharactersByTier[tier].contains(characterID)) {
-            _matchableCharactersByTier[tier].remove(characterID);
-        }
+        _matchableCharactersByTier[tier].remove(characterID);
 
         isCharacterInArena[characterID] = false;
         isWeaponInArena[weaponID] = false;


### PR DESCRIPTION
Contract size reduction by restructuring various functions.


24550 bytes
- `-35` `PvpArena.getDuelCost()`

24515 bytes

- `-4` `PvpArena.getArenaTier()`

24511 bytes

- `-51` `PvpArena.getTierTopCharacters()`

24460 bytes

- `-120` `PvpArena.getPrizePercentages()`

24340 bytes

- `-87` `PvpArena._assignOpponent()`

24253 bytes

- `-42` `PvpArena._assignRewards()`

24211 bytes

- `-40` `PvpArena._removeCharacterFromArena()`

24171 bytes

- `-137` `PvpArena._getCharacterPowerRoll()`

24034 bytes

- `-2` `PvpArena.getCharacterPower()`

24032 bytes

- `-59` `PvpArena._getShieldStats()`

23973 bytes