### PR TITLE
Don't use precision on the ratio in the claim rewards bar, so the claimable value is correct.

### DIFF
--- a/frontend/src/components/smart/ClaimRewardsBar.vue
+++ b/frontend/src/components/smart/ClaimRewardsBar.vue
@@ -125,7 +125,7 @@
           <h6 v-if="formattedMultiplier < 0.5" class="very-low-multiplier">{{$t('ClaimRewardsBar.lowMultiplier', {currentMultiplier})}}</h6>
           <h6 >{{
               $t('ClaimRewardsBar.realWithdrawValueClaimable', {
-                actualAmount: (skillAmount / formattedRatio * formattedMultiplier).toFixed(4),
+                actualAmount: (skillAmount / nonFormattedRatio * formattedMultiplier).toFixed(4),
                 tokenSymbol: selectedPartneredProject.tokenSymbol,
                 skillAmount: (+skillAmount).toFixed(4)
               })
@@ -223,9 +223,9 @@ export default Vue.extend({
       return this.selectedPartneredProject && +toBN(this.partnerProjectMultipliers[+this.selectedPartneredProject.id]).div(toBN(10).pow(18)).toFixed(4) || 1;
     },
 
-    formattedRatio(): number {
+    nonFormattedRatio(): number {
       return this.selectedPartneredProject &&
-        +toBN(1).dividedBy(toBN(this.partnerProjectRatios[+this.selectedPartneredProject.id]).dividedBy(toBN(2).exponentiatedBy(64))).toFixed(4) || 1;
+        +toBN(1).dividedBy(toBN(this.partnerProjectRatios[+this.selectedPartneredProject.id]).dividedBy(toBN(2).exponentiatedBy(64))) || 1;
     },
 
     formattedSkillReward(): string {


### PR DESCRIPTION
Before:
![Screenshot from 2022-03-13 21-11-41](https://user-images.githubusercontent.com/41158626/158077419-f9a9da14-ed80-44cc-81eb-1d5d9260625d.png)

After:
![Screenshot from 2022-03-13 21-09-51](https://user-images.githubusercontent.com/41158626/158077433-6b516ee7-e46e-4c62-a5d0-269e574bcaed.png)

### PR Description

This solves the following issue: https://github.com/CryptoBlades/cryptoblades/issues/1222

The above images show a before and after this change.

### Testing

The code has only been tested by me, but I am not sure if someone needs to check on it.