### PR TITLE
Fix collision issue between KING and SKILL BasicPriceOracle proxies

### DIFF
--- a/migrations/100_nftstorage_logging_for_bot.js
+++ b/migrations/100_nftstorage_logging_for_bot.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const NFTStorage = artifacts.require("NFTStorage");
 

--- a/migrations/101_nftstorage_fee.js
+++ b/migrations/101_nftstorage_fee.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const CryptoBlades = artifacts.require("CryptoBlades");
 const NFTStorage = artifacts.require("NFTStorage");

--- a/migrations/103_nftstorage_restoremints.js
+++ b/migrations/103_nftstorage_restoremints.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const Weapons = artifacts.require("Weapons");
 const Characters = artifacts.require("Characters");

--- a/migrations/105_king_staking.js
+++ b/migrations/105_king_staking.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { deployProxy } = require('@openzeppelin/truffle-upgrades');
 
 const KingStakingRewardsUpgradeable = artifacts.require('KingStakingRewardsUpgradeable');
 

--- a/migrations/106_nftstorage_setchainid_on_bridge.js
+++ b/migrations/106_nftstorage_setchainid_on_bridge.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const NFTStorage = artifacts.require("NFTStorage");
 module.exports = async function (deployer, network, accounts) {

--- a/migrations/109_king_staking_upgrade.js
+++ b/migrations/109_king_staking_upgrade.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const KingStakingRewardsUpgradeable = artifacts.require('KingStakingRewardsUpgradeable');
 

--- a/migrations/115_pvp_arena_new.js
+++ b/migrations/115_pvp_arena_new.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+const { deployProxy } = require("@openzeppelin/truffle-upgrades");
 
 const CryptoBlades = artifacts.require("CryptoBlades");
 const PvpArena = artifacts.require("PvpArena");

--- a/migrations/121_pvp_arena_mainnet.js
+++ b/migrations/121_pvp_arena_mainnet.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+const { deployProxy } = require("@openzeppelin/truffle-upgrades");
 
 const CryptoBlades = artifacts.require("CryptoBlades");
 const PvpArena = artifacts.require("PvpArena");

--- a/migrations/123_bridge_shields.js
+++ b/migrations/123_bridge_shields.js
@@ -1,4 +1,4 @@
-const { upgradeProxy, deployProxy } = require("@openzeppelin/truffle-upgrades");
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
 const Shields = artifacts.require("Shields");
 const NFTStorage = artifacts.require("NFTStorage");
 const Blacksmith = artifacts.require("Blacksmith");

--- a/migrations/136_special_weapons.js
+++ b/migrations/136_special_weapons.js
@@ -1,11 +1,13 @@
 const { upgradeProxy, deployProxy } = require("@openzeppelin/truffle-upgrades");
+const { requireNamedProxy } = require('./utils/named-proxy');
+
 const Weapons = artifacts.require("Weapons");
 const Promos = artifacts.require("Promos");
 const SafeRandoms = artifacts.require("SafeRandoms");
 const SpecialWeaponsManager = artifacts.require("SpecialWeaponsManager");
 const CryptoBlades = artifacts.require("CryptoBlades");
 const BurningManager = artifacts.require("BurningManager");
-const BasicPriceOracle = artifacts.require("BasicPriceOracle");
+const SkillPriceOracle = requireNamedProxy('BasicPriceOracle', 'SkillPriceOracle');
 const PvpArena = artifacts.require("PvpArena");
 const NFTStorage = artifacts.require("NFTStorage");
 const SkillStakingRewardsUpgradeable = artifacts.require("SkillStakingRewardsUpgradeable");
@@ -26,7 +28,7 @@ module.exports = async function (deployer, network) {
     let weapons = await upgradeProxy(Weapons.address, Weapons, { deployer });
     let promos = await upgradeProxy(Promos.address, Promos, { deployer });
     let safeRandoms = await SafeRandoms.deployed();
-    let priceOracle = await BasicPriceOracle.deployed();
+    let priceOracle = await SkillPriceOracle.deployed();
     let game = await upgradeProxy(CryptoBlades.address, CryptoBlades, { deployer });
     let specialWeaponsManager = await deployProxy(SpecialWeaponsManager, [promos.address, weapons.address, safeRandoms.address, game.address, priceOracle.address], { deployer });
 

--- a/migrations/137_nft_storage_upgrade.js
+++ b/migrations/137_nft_storage_upgrade.js
@@ -1,4 +1,4 @@
-const { upgradeProxy, deployProxy } = require("@openzeppelin/truffle-upgrades");
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
 const NFTStorage = artifacts.require("NFTStorage");
 const Weapons = artifacts.require("Weapons");
 

--- a/migrations/138_special_weapons mainnet.js
+++ b/migrations/138_special_weapons mainnet.js
@@ -1,11 +1,13 @@
 const { upgradeProxy, deployProxy } = require("@openzeppelin/truffle-upgrades");
+const { requireNamedProxy } = require('./utils/named-proxy');
+
 const Weapons = artifacts.require("Weapons");
 const Promos = artifacts.require("Promos");
 const SafeRandoms = artifacts.require("SafeRandoms");
 const SpecialWeaponsManager = artifacts.require("SpecialWeaponsManager");
 const CryptoBlades = artifacts.require("CryptoBlades");
 const BurningManager = artifacts.require("BurningManager");
-const BasicPriceOracle = artifacts.require("BasicPriceOracle");
+const SkillPriceOracle = requireNamedProxy('BasicPriceOracle', 'SkillPriceOracle');
 const PvpArena = artifacts.require("PvpArena");
 const NFTStorage = artifacts.require("NFTStorage");
 const SkillStakingRewardsUpgradeable = artifacts.require("SkillStakingRewardsUpgradeable");
@@ -24,7 +26,7 @@ module.exports = async function (deployer, network) {
     let weapons = await upgradeProxy(Weapons.address, Weapons, { deployer });
     let promos = await Promos.deployed();
     let safeRandoms = await SafeRandoms.deployed();
-    let priceOracle = await BasicPriceOracle.deployed();
+    let priceOracle = await SkillPriceOracle.deployed();
     let game = await upgradeProxy(CryptoBlades.address, CryptoBlades, { deployer });
     let specialWeaponsManager = await deployProxy(SpecialWeaponsManager, [promos.address, weapons.address, safeRandoms.address, game.address, priceOracle.address], { deployer });
 

--- a/migrations/143_repair_basic_oracle_proxies.js
+++ b/migrations/143_repair_basic_oracle_proxies.js
@@ -1,0 +1,28 @@
+const { hasNamedProxy, setNamedProxyAddress } = require('./utils/named-proxy');
+
+const BasicPriceOracle = artifacts.require('BasicPriceOracle');
+const Blacksmith = artifacts.require('Blacksmith');
+const CryptoBlades = artifacts.require("CryptoBlades");
+
+module.exports = async function (deployer) {
+  const priceOracle = await BasicPriceOracle.deployed();
+
+  if (!hasNamedProxy(priceOracle, 'SkillPriceOracle')) {
+    game = await CryptoBlades.deployed();
+
+    const skillPriceOracleAddress = await game.priceOracleSkillPerUsd();
+
+    console.log(`Adding proxy address [${skillPriceOracleAddress}] for SkillPriceOracle`)
+    setNamedProxyAddress(priceOracle, 'SkillPriceOracle', skillPriceOracleAddress);
+  }
+
+  if (!hasNamedProxy(priceOracle, 'KingPriceOracle')) {
+    blacksmith = await Blacksmith.deployed();
+
+    const LINK_KING_ORACLE = await blacksmith.LINK_KING_ORACLE();
+    const kingPriceOracleAddress = await blacksmith.getLink(LINK_KING_ORACLE);
+
+    console.log(`Adding proxy address [${kingPriceOracleAddress}] for KingPriceOracle`)
+    setNamedProxyAddress(priceOracle, 'KingPriceOracle', kingPriceOracleAddress);
+  }
+};

--- a/migrations/144_test_basic_oracle_proxies.js
+++ b/migrations/144_test_basic_oracle_proxies.js
@@ -1,0 +1,22 @@
+const { requireNamedProxy } = require('./utils/named-proxy');
+
+const BasicPriceOracle = artifacts.require('BasicPriceOracle');
+const KingPriceOracle = requireNamedProxy('BasicPriceOracle', 'KingPriceOracle');
+const SkillPriceOracle = requireNamedProxy('BasicPriceOracle', 'SkillPriceOracle');
+
+module.exports = async function (deployer) {
+  const priceOracle = await BasicPriceOracle.deployed();
+  console.log(`${priceOracle.address} BasicPriceOracle`);
+  console.log((await priceOracle.currentPrice()).toString());
+  console.log()
+
+  const skillPriceOracle = await SkillPriceOracle.deployed();
+  console.log(`${skillPriceOracle.address} SkillPriceOracle`);
+  console.log((await skillPriceOracle.currentPrice()).toString());
+  console.log()
+
+  const kingPriceOracle = await KingPriceOracle.deployed();
+  console.log(`${kingPriceOracle.address} KingPriceOracle`);
+  console.log((await kingPriceOracle.currentPrice()).toString());
+  console.log()
+};

--- a/migrations/38_skill-staking_from_unclaimed_rewards.js
+++ b/migrations/38_skill-staking_from_unclaimed_rewards.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const SkillStakingRewardsUpgradeable = artifacts.require("SkillStakingRewardsUpgradeable");
 const LPStakingRewardsUpgradeable = artifacts.require("LPStakingRewardsUpgradeable");

--- a/migrations/42_sqrt_payout_curve.js
+++ b/migrations/42_sqrt_payout_curve.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const CryptoBlades = artifacts.require("CryptoBlades");
 

--- a/migrations/67_surprise.js
+++ b/migrations/67_surprise.js
@@ -1,4 +1,4 @@
-const { upgradeProxy, deployProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const Weapons = artifacts.require('Weapons');
 const Promos = artifacts.require('Promos');

--- a/migrations/68_surprise_adjustment.js
+++ b/migrations/68_surprise_adjustment.js
@@ -1,4 +1,4 @@
-const { upgradeProxy, deployProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const Promos = artifacts.require('Promos');
 const NFTMarket = artifacts.require("NFTMarket");

--- a/migrations/8_main_game.js
+++ b/migrations/8_main_game.js
@@ -1,5 +1,6 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades');
 const assert = require('assert');
+const { deployNamedProxy } = require('./utils/named-proxy');
 
 const BasicPriceOracle = artifacts.require("BasicPriceOracle");
 const DummyRandoms = artifacts.require("DummyRandoms");
@@ -44,7 +45,7 @@ module.exports = async function (deployer, network) {
   assert(skillToken != null, 'Expected skillToken to be set to a contract');
   assert(randoms != null, 'Expected random to be set to a contract');
 
-  const priceOracle = await deployProxy(BasicPriceOracle, [], { deployer });
+  const priceOracle = await deployNamedProxy(BasicPriceOracle, [], { deployer }, 'SkillPriceOracle');
 
   const charas = await deployProxy(Characters, [], { deployer });
 

--- a/migrations/92_cbkLandSale_reservedSales.js
+++ b/migrations/92_cbkLandSale_reservedSales.js
@@ -1,4 +1,5 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { deployNamedProxy } = require('./utils/named-proxy');
 
 const CryptoBlades = artifacts.require("CryptoBlades");
 const Blacksmith = artifacts.require("Blacksmith");
@@ -18,7 +19,7 @@ module.exports = async function (deployer, network, accounts) {
     const LINK_SKILL_ORACLE_2 = await blacksmith.LINK_SKILL_ORACLE_2();
     await blacksmith.setLink(LINK_SKILL_ORACLE_2, skillOracle.address);
 
-    const kingOracle = await deployProxy(BasicPriceOracle, [], { deployer });
+    const kingOracle = await deployNamedProxy(BasicPriceOracle, [], { deployer }, 'KingPriceOracle');
     await kingOracle.setCurrentPrice("3333333333333333333"); // about 0.3 usd per king
     const LINK_KING_ORACLE = await blacksmith.LINK_KING_ORACLE();
     await blacksmith.setLink(LINK_KING_ORACLE, kingOracle.address);

--- a/migrations/93_cbkLandSale_reservedSales_updateReseller.js
+++ b/migrations/93_cbkLandSale_reservedSales_updateReseller.js
@@ -1,5 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
-
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const CBKLandSale = artifacts.require("CBKLandSale");
 

--- a/migrations/94_cbkLandSale_massMint.js
+++ b/migrations/94_cbkLandSale_massMint.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const CBKLandSale = artifacts.require("CBKLandSale");
 const CBKLand = artifacts.require("CBKLand");

--- a/migrations/97_nftstorage_update.js
+++ b/migrations/97_nftstorage_update.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const NFTStorage = artifacts.require("NFTStorage");
 

--- a/migrations/98_cbkLandSale_massClaim.js
+++ b/migrations/98_cbkLandSale_massClaim.js
@@ -1,4 +1,4 @@
-const { deployProxy, upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
 
 const CBKLandSale = artifacts.require("CBKLandSale");
 

--- a/migrations/utils/named-proxy.js
+++ b/migrations/utils/named-proxy.js
@@ -1,0 +1,18 @@
+const { deployProxy } = require('@openzeppelin/truffle-upgrades');
+
+async function deployNamedProxy(Contract, args, opts, name) {
+  const chainId = opts.deployer.network_id;
+  const contract = await deployProxy(Contract, args, opts);
+
+  if (contract.constructor._json.networks[chainId].namedProxies === undefined) {
+      contract.constructor._json.networks[chainId].namedProxies = {}
+  }
+  contract.constructor._json.networks[chainId].namedProxies[name] = contract.address;
+
+  return contract;
+}
+
+module.exports = {
+  deployNamedProxy: deployNamedProxy
+}
+

--- a/migrations/utils/named-proxy.js
+++ b/migrations/utils/named-proxy.js
@@ -14,6 +14,24 @@ function hasNamedProxy(contract, proxyName) {
   return (proxyName in contract.constructor._json.networks[chainId].namedProxies)
 }
 
+function requireNamedProxy(ImplementationClassName, proxyName) {
+  const implementationClass = artifacts.require(ImplementationClassName);
+
+  implementationClass.deployedDefault = implementationClass.deployed;
+  implementationClass.deployed = async function() {
+    const proxyContract = await implementationClass.deployedDefault();
+
+    const chainId = implementationClass.network_id;
+    proxyAddress = proxyContract.constructor._json.networks[chainId].namedProxies[proxyName]
+    proxyContract.address = proxyAddress;
+    proxyContract.contract._address = proxyAddress;
+
+    return proxyContract;
+  };
+
+  return implementationClass;
+}
+
 function setNamedProxyAddress(contract, proxyName, proxyAddress) {
   const chainId = contract.constructor.network_id;
   if (contract.constructor._json.networks[chainId].namedProxies === undefined)
@@ -24,6 +42,6 @@ function setNamedProxyAddress(contract, proxyName, proxyAddress) {
 module.exports = {
   deployNamedProxy: deployNamedProxy,
   hasNamedProxy: hasNamedProxy,
+  requireNamedProxy: requireNamedProxy,
   setNamedProxyAddress: setNamedProxyAddress
 }
-

--- a/migrations/utils/named-proxy.js
+++ b/migrations/utils/named-proxy.js
@@ -7,6 +7,13 @@ async function deployNamedProxy(Contract, args, opts, name) {
   return contract;
 }
 
+function hasNamedProxy(contract, proxyName) {
+  const chainId = contract.constructor.network_id;
+  if (contract.constructor._json.networks[chainId].namedProxies === undefined)
+    return false;
+  return (proxyName in contract.constructor._json.networks[chainId].namedProxies)
+}
+
 function setNamedProxyAddress(contract, proxyName, proxyAddress) {
   const chainId = contract.constructor.network_id;
   if (contract.constructor._json.networks[chainId].namedProxies === undefined)
@@ -16,6 +23,7 @@ function setNamedProxyAddress(contract, proxyName, proxyAddress) {
 
 module.exports = {
   deployNamedProxy: deployNamedProxy,
+  hasNamedProxy: hasNamedProxy,
   setNamedProxyAddress: setNamedProxyAddress
 }
 

--- a/migrations/utils/named-proxy.js
+++ b/migrations/utils/named-proxy.js
@@ -3,16 +3,19 @@ const { deployProxy } = require('@openzeppelin/truffle-upgrades');
 async function deployNamedProxy(Contract, args, opts, name) {
   const chainId = opts.deployer.network_id;
   const contract = await deployProxy(Contract, args, opts);
-
-  if (contract.constructor._json.networks[chainId].namedProxies === undefined) {
-      contract.constructor._json.networks[chainId].namedProxies = {}
-  }
-  contract.constructor._json.networks[chainId].namedProxies[name] = contract.address;
-
+  setNamedProxyAddress(contract, name, contract.address);
   return contract;
 }
 
+function setNamedProxyAddress(contract, proxyName, proxyAddress) {
+  const chainId = contract.constructor.network_id;
+  if (contract.constructor._json.networks[chainId].namedProxies === undefined)
+      contract.constructor._json.networks[chainId].namedProxies = {}
+  contract.constructor._json.networks[chainId].namedProxies[proxyName] = proxyAddress;
+}
+
 module.exports = {
-  deployNamedProxy: deployNamedProxy
+  deployNamedProxy: deployNamedProxy,
+  setNamedProxyAddress: setNamedProxyAddress
 }
 


### PR DESCRIPTION
### Summary

For local deployments, the `BasicPriceOracle` used for `SpecialWeaponsManager` ends up as the KING oracle rather than the SKILL oracle.  When deploying multiple proxies with the same implementation, the last one "wins".  Migration 92 deploys the KING oracle after migration 8 deploys the SKILL oracle. The result is that all subsequent migrations that attempt to use BasicPriceOracle will use the KING oracle rather than the SKILL oracle.

The solution is to record the proxy addresses by name in a different location in the json and then use that information to reach the desired proxy by name.

### Commits

This change includes the following commits:
- Remove deployProxy import where unused
- Remove upgradeProxy import where unused
- Add deployNamedProxy()
- Migration 8 now uses deployNamedProxy()
- Migration 92 now uses deployNamedProxy()
- Add setNamedProxyAddress()
- Add hasNamedProxy()
- Add 143_repair_basic_oracle_proxies.js
- Add 144_test_basic_oracle_proxies.js
- Add requireNamedProxy()
- Fix oracle in migration 136
- Fix oracle in migration 138

### Testing

- Verified that fresh deployments have both the KING and SKILL oracle addresses in build/contracts/BasicPriceOracle.json
- Verified the "old" deployments (without the fixes to migrations 8, 92, 136, and 138 applied) are repaired by migration 143
- Verified that `SpecialWeaponsManager.priceOracleSkillPerUsd` points to the Skill oracle for both fresh and "old" deployments
- Verified (via migration 144) that both KING and SKILL oracles are directly accessible by future migrations