### PR TITLE
Show error message when attempting to raid with insufficient funds.

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -431,6 +431,7 @@
     "errors": {
       "selection": "Check Character and Weapon Selection and try again...",
       "raidNotStarted": "Raid has not started yet...",
+      "cannotAffordRaid": "Insufficient funds...",
       "lockedChar": "Selected character is locked in the raid already...",
       "lockedWeapon": "Selected weapon is locked in the raid already...",
       "notEnough": "Not enough stamina or durability...",


### PR DESCRIPTION
### Screenshots
# With sufficient funds:
![Screenshot from 2022-03-14 14-11-11](https://user-images.githubusercontent.com/41158626/158180340-6160debc-0727-4f62-84ed-1b2e89f834c0.png)

![Screenshot from 2022-03-14 14-11-18](https://user-images.githubusercontent.com/41158626/158180474-68ea8cdd-609f-4c79-b4c8-fccec80ef6b6.png)

# With insufficient funds
![Screenshot from 2022-03-14 14-11-40](https://user-images.githubusercontent.com/41158626/158180542-67109efc-e3de-4aaa-880f-a2b4b537635c.png)
![Screenshot from 2022-03-14 14-17-06](https://user-images.githubusercontent.com/41158626/158180569-3db23212-ded8-4f90-88ad-9dae2768521e.png)

### PR Description
Solves this issue: https://github.com/CryptoBlades/cryptoblades/issues/1253

An error message will be shown when the user has insufficient funds to start the raid.

### Testing

Has been tested by me, but might need double checking.