### PR TITLE
Fix to incrementQuestProgress()

### DIFF
--- a/contracts/SimpleQuests.sol
+++ b/contracts/SimpleQuests.sol
@@ -416,7 +416,9 @@ contract SimpleQuests is Initializable, AccessControlUpgradeable {
         characters.setNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS, currentProgress + progress);
         emit QuestProgressed(questID, characterID);
         if (quests[characterQuest[characterID]].requirementAmount <= currentProgress + progress) {
-            generateRewardQuestSeed(characterID);
+            if (!hasRandomQuestRewardSeedRequested(characterID)) {
+                generateRewardQuestSeed(characterID);
+            }
         }
     }
 


### PR DESCRIPTION
For users that invoke `generateRewardQuestSeed()` "early", attempts by `incrementQuestProgress()` to do that automatically will fail.

This change makes `incrementQuestProgress()` resilient to that scenario.

This should address the scenario some users are facing where they can successfully submit partial amounts for a quest but when they attempt to submit the required amount it fails.

### Root cause
Users can arrive in the broken state one of two ways directly from the game UI:

Scenario A - Before #1235 

1. Submit a quest (fully)
2. Accept in Metamask
3. Click complete button
4. Accept generate in Metamask
5. Reject complete in Metamask
6. Click skip button
7. Accept in Metamask

Scenario B - After #1235 

1. Submit a quest (fully)
2. Accept in Metamask
3. Click skip button
4. Accept in Metamask