### PR TITLE
Quest seed fix

### DIFF
--- a/contracts/SafeRandoms.sol
+++ b/contracts/SafeRandoms.sol
@@ -113,11 +113,23 @@ contract SafeRandoms is Initializable, AccessControlUpgradeable {
 
     function requestSingleSeed(address user, uint256 requestID) public restricted {
         _resolveSeedPublic(user);
-        _requestSingleSeed(user, requestID);
+        _requestSingleSeedAssert(user, requestID);
     }
 
-    function _requestSingleSeed(address user, uint256 requestID) internal {
+    function requestSingleSeed(address user, uint256 requestID, bool force) public restricted {
+        _resolveSeedPublic(user);
+        if(force)
+            _requestSingleSeed(user, requestID);
+        else
+            _requestSingleSeedAssert(user, requestID);
+    }
+
+    function _requestSingleSeedAssert(address user, uint256 requestID) internal {
         require(singleSeedRequests[user][requestID] == 0);
+        _requestSingleSeed(user, requestID);
+    }
+    
+    function _requestSingleSeed(address user, uint256 requestID) internal {
         singleSeedRequests[user][requestID] = currentSeedIndex;
         if(firstRequestBlockNumber < seedIndexBlockNumber)
             firstRequestBlockNumber = block.number;

--- a/contracts/SimpleQuests.sol
+++ b/contracts/SimpleQuests.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./cryptoblades.sol";
 import "./characters.sol";
 import "./weapons.sol";
@@ -18,6 +19,7 @@ contract SimpleQuests is Initializable, AccessControlUpgradeable {
 
     using ABDKMath64x64 for int128;
     using ABDKMath64x64 for uint256;
+    using SafeMath for uint256;
 
     bytes32 public constant GAME_ADMIN = keccak256("GAME_ADMIN");
     uint256 internal constant SEED_RANDOM_QUEST = uint(keccak256("SEED_RANDOM_QUEST"));
@@ -268,8 +270,14 @@ contract SimpleQuests is Initializable, AccessControlUpgradeable {
         assignNewQuest(characterID);
     }
 
-    function generateRewardQuestSeed(uint256 characterID) assertQuestsEnabled assertOwnsCharacter(characterID) public {
-        safeRandoms.requestSingleSeed(address(this), RandomUtil.combineSeeds(SEED_REWARD_QUEST, characterID));
+    function generateRewardQuestSeed(uint256 characterID) assertQuestsEnabled assertOwnsCharacter(characterID) assertOnQuest(characterID, true) public {
+        uint256[] memory questData = getCharacterQuestData(characterID);
+        require(questData[0] >= quests[characterQuest[characterID]].requirementAmount);
+        _generateRewardQuestSeed(characterID, false);
+    }
+
+    function _generateRewardQuestSeed(uint256 characterID, bool forced) internal {
+        safeRandoms.requestSingleSeed(address(this), RandomUtil.combineSeeds(SEED_REWARD_QUEST, characterID), forced);
     }
 
     function rewardQuest(uint256 questID, uint256 characterID) private returns (uint256[] memory) {
@@ -412,11 +420,12 @@ contract SimpleQuests is Initializable, AccessControlUpgradeable {
     }
 
     function incrementQuestProgress(uint256 characterID, uint256 questID, uint256 progress) private {
+        require(progress > 0);
         uint currentProgress = characters.getNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS);
         characters.setNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS, currentProgress + progress);
         emit QuestProgressed(questID, characterID);
-        if (quests[characterQuest[characterID]].requirementAmount <= currentProgress + progress) {
-            generateRewardQuestSeed(characterID);
+        if (quests[characterQuest[characterID]].requirementAmount.sub(progress) == currentProgress) {
+            _generateRewardQuestSeed(characterID, true);
         }
     }
 

--- a/contracts/SimpleQuests.sol
+++ b/contracts/SimpleQuests.sol
@@ -421,10 +421,10 @@ contract SimpleQuests is Initializable, AccessControlUpgradeable {
 
     function incrementQuestProgress(uint256 characterID, uint256 questID, uint256 progress) private {
         require(progress > 0);
-        uint currentProgress = characters.getNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS);
-        characters.setNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS, currentProgress + progress);
+        uint totalProgress = characters.getNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS) + progress;
+        characters.setNftVar(characterID, NFTVAR_SIMPLEQUEST_PROGRESS, totalProgress);
         emit QuestProgressed(questID, characterID);
-        if (quests[characterQuest[characterID]].requirementAmount.sub(progress) == currentProgress) {
+        if (quests[characterQuest[characterID]].requirementAmount.sub(totalProgress) == 0) {
             _generateRewardQuestSeed(characterID, true);
         }
     }

--- a/migrations/146_quest_seed_fix.js
+++ b/migrations/146_quest_seed_fix.js
@@ -1,0 +1,9 @@
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+
+const SimpleQuests = artifacts.require('SimpleQuests');
+const SafeRandoms = artifacts.require("SafeRandoms");
+
+module.exports = async function (deployer, network) {
+  await upgradeProxy(SimpleQuests.address, SimpleQuests, { deployer });
+  await upgradeProxy(SafeRandoms.address, SafeRandoms, { deployer });
+};


### PR DESCRIPTION
An improvement over #1261
It was still possible to request a reward seed early, so I fixed that.
I added a tightly controlled force request call in case we change requirement amounts of quests in the future that would trip up users who have requested a seed but not completed yet by the time the quest input changed.

Credit for the overpay check goes to PR #1233 but due to the seed fix I had to use an altered solution

The code has not been tested yet, but it does compile and deploy fine