### PR TITLE
SafeRandoms single seed salt fix

### DIFF
--- a/migrations/148_single_seed_salt_fix.js
+++ b/migrations/148_single_seed_salt_fix.js
@@ -1,0 +1,7 @@
+const { upgradeProxy } = require('@openzeppelin/truffle-upgrades');
+
+const SafeRandoms = artifacts.require("SafeRandoms");
+
+module.exports = async function (deployer, network) {
+  await upgradeProxy(SafeRandoms.address, SafeRandoms, { deployer });
+};


### PR DESCRIPTION
### PR Description

SafeRandoms was meant to have different results per request, this includes different users making requests at the same times as well as the same user making requests for different things (ie requesting a quest for two characters simultaneously).
I forgot to salt the resulting seed with the user and requestID values, causing uniform outcomes for various actions on the same seedIndex.

The fix still returns 0 for the cases where we want to allow it (mostly frontend or contract level checks where we want to see if it is a fulfilled seed or not)

### Testing

Compiled, locally deployed, not run the functions yet to verify outcomes
EDIT: Did a quick local test. Seemed fine, but then, it's hard to verify blocknumber related things with ganache