### PR TITLE
Feat/pvp  split contract frontend fixes

### DIFF
--- a/frontend/src/components/smart/PvPArenaPreparation.vue
+++ b/frontend/src/components/smart/PvPArenaPreparation.vue
@@ -167,9 +167,9 @@
           <div class="enterArenaButtonWrapper">
             <pvp-button
               class="pvpButton"
-              @click="handleEnterArenaClick(false)"
+              @click="handleEnterArenaClick(true)"
               :buttonText="$t('pvp.enterArena')"
-              :buttonsubText="$t('pvp.tiered')"
+              :buttonsubText="$t('pvp.untiered')"
               :class="{ disabled: !this.checkBoxAgreed || !this.selectedWeaponId}"
               secondary
             />
@@ -177,9 +177,9 @@
           <div class="enterArenaButtonWrapper">
             <pvp-button
               class="pvpButton"
-              @click="handleEnterArenaClick(true)"
+              @click="handleEnterArenaClick(false)"
               :buttonText="$t('pvp.enterArena')"
-              :buttonsubText="$t('pvp.untiered')"
+              :buttonsubText="$t('pvp.tiered')"
               :class="{ disabled: !this.checkBoxAgreed || !this.selectedWeaponId}"
               secondary
             />

--- a/frontend/src/components/smart/PvPRewards.vue
+++ b/frontend/src/components/smart/PvPRewards.vue
@@ -58,7 +58,9 @@ export default {
   methods: {
     ...mapActions([
       'withdrawRankedRewards',
-      'getPlayerPrizePoolRewards'
+      'withdrawRankedRewardsOldContract',
+      'getPlayerPrizePoolRewards',
+      'getPlayerPrizePoolRewardsOldContract'
     ]),
 
     async claimRewards() {
@@ -66,8 +68,9 @@ export default {
 
       try {
         await this.withdrawRankedRewards();
+        await this.withdrawRankedRewardsOldContract();
 
-        this.availableSkill = await this.getPlayerPrizePoolRewards();
+        this.availableSkill = +(await this.getPlayerPrizePoolRewards()) + +(await this.getPlayerPrizePoolRewardsOldContract());
       } catch (err) {
         console.log('withdraw rewards error: ', err);
       }
@@ -77,7 +80,7 @@ export default {
   },
 
   async created() {
-    this.availableSkill = await this.getPlayerPrizePoolRewards();
+    this.availableSkill = +(await this.getPlayerPrizePoolRewards()) + +(await this.getPlayerPrizePoolRewardsOldContract());
 
     this.loading = false;
   }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1228,7 +1228,7 @@
     "noShields": "You have no shields.",
     "enterTheArena": "Enter the Arena",
     "enterArenaWillCost": " Tiered arena entrance is {formattedEntryWager} $SKILL.",
-    "enterUntieredArenaWillCost": " Untiered arena entrance is {formattedUntieredEntryWager} $SKILL.",
+    "enterUntieredArenaWillCost": " Free for all arena entrance is {formattedUntieredEntryWager} $SKILL.",
     "playersCanAttackYou": " Players can attack you while you are in the Arena.",
     "leavingWillCost": " Leaving the Arena will cost you {leavingArenaCost} $SKILL.",
     "iUnderstand": "I understand.",
@@ -1304,9 +1304,9 @@
     "rankToEarn": "Ranking points you will earn if victorious",
     "goodLuck": "Good luck!",
     "tieredArena": "Tiered: Face players of similar levels",
-    "untieredArena": "Untiered: Fight players of any level!",
+    "untieredArena": "Free for All: Fight players of any level!",
     "tiered": "Tiered",
-    "untiered": "Untiered"
+    "untiered": "Free for All"
   },
   "app": {
     "cantView": "You can't currently view the app right now. You can try clearing LocalStorage to reset your settings.",

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -5650,6 +5650,15 @@ export function createStore(web3: Web3) {
         return playerPrizePoolRewards;
       },
 
+      async getPlayerPrizePoolRewardsOldContract({ state }) {
+        const { PvpArena } = state.contracts();
+        if (!PvpArena || !state.defaultAccount) return;
+
+        const playerPrizePoolRewards = await PvpArena.methods.getPlayerPrizePoolRewards().call({ from: state.defaultAccount });
+
+        return playerPrizePoolRewards;
+      },
+
       async getDuelOffsetCost({ state }) {
         const { PvpCore } = state.contracts();
         if (!PvpCore || !state.defaultAccount) return;
@@ -5713,6 +5722,15 @@ export function createStore(web3: Web3) {
         if (!PvpRankings || !state.defaultAccount) return;
 
         const res = await PvpRankings.methods.withdrawRankedRewards().send({ from: state.defaultAccount });
+
+        return res;
+      },
+
+      async withdrawRankedRewardsOldContract({ state }) {
+        const { PvpArena } = state.contracts();
+        if (!PvpArena || !state.defaultAccount) return;
+
+        const res = await PvpArena.methods.withdrawRankedRewards().send({ from: state.defaultAccount });
 
         return res;
       },

--- a/frontend/src/views/PvP.vue
+++ b/frontend/src/views/PvP.vue
@@ -45,7 +45,8 @@ export default {
 
   methods: {
     ...mapActions([
-      'getPlayerPrizePoolRewards'
+      'getPlayerPrizePoolRewards',
+      'getPlayerPrizePoolRewardsOldContract'
     ]),
 
     // TODO: Use router for this.
@@ -63,12 +64,12 @@ export default {
   },
 
   async created() {
-    const playerRewards = await this.getPlayerPrizePoolRewards();
+    const playerRewards = +(await this.getPlayerPrizePoolRewards()) + +(await this.getPlayerPrizePoolRewardsOldContract());
     this.hasRewards = !!+playerRewards;
   },
 
   async updated() {
-    const playerRewards = await this.getPlayerPrizePoolRewards();
+    const playerRewards = +(await this.getPlayerPrizePoolRewards()) + +(await this.getPlayerPrizePoolRewardsOldContract());
 
     this.hasRewards = !!+playerRewards;
   }


### PR DESCRIPTION
This PR:
- Tweaks "withdrawRankedRewards" to work on old PvpArena contract and new PvpCore contract, so users don't leave unclaimed rewards behind when we migrate.
- Swaps tiered and untiered arena buttons position. Also renames "untiered" to "free for all"