### PR TITLE
Link nfts to bazaar

### DIFF
--- a/frontend/src/views/NftDisplay.vue
+++ b/frontend/src/views/NftDisplay.vue
@@ -89,19 +89,19 @@
               </span>
               <a :href="marketLink" target="_blank" rel="noopener noreferrer">
                 <big-button
+                class="encounter-button btn-styled purchase-button"
                 variant="primary"
-                class="purchase-button"
                 :mainText="`Buy on Bazaar!`"
                 >
               </big-button>
             </a>
+            <big-button
+              v-if="ownerAddress"
+              class="encounter-button btn-styled copy-url-button"
+              :mainText="`Copy URL`"
+              @click="copyNftUrl"
+            />
           </div>
-          <big-button
-            v-if="ownerAddress"
-            class="encounter-button btn-styled copy-url-button"
-            :mainText="`Copy URL`"
-            @click="copyNftUrl"
-          />
           </div>
         </div>
       </div>
@@ -380,7 +380,14 @@ export default Vue.extend({
   padding: 40px 0;
   margin: 10px 0;
 }
+/deep/ .nft-list {
+  padding: 40px 0;
+  margin: 10px 0;
+}
 .search-button {
+  width: 22em;
+}
+.purchase-section * {
   width: 100%;
 }
 
@@ -396,11 +403,6 @@ export default Vue.extend({
 
 .copy-url-button{
   margin-top: 10px;
-}
-
-.copy-url-button,
-.purchase-button {
-  width: 100%;
 }
 
 .btn-section{
@@ -452,7 +454,7 @@ export default Vue.extend({
   .nft-list,
   .weapon-grid,
   .character-list {
-    transform: scale(1);
+    transform: scale(1.25);
   }
 
   .nft-list,

--- a/frontend/src/views/NftDisplay.vue
+++ b/frontend/src/views/NftDisplay.vue
@@ -87,20 +87,14 @@
                 <strong>Price</strong>:
                 <CurrencyConverter :skill="nftPriceInSkill()" />
               </span>
-            <!--
-
-              ***TODO: Add link to bazaar here***
-
-              <big-button
-              @click="
-                selectedNftId = id;
-              "
-              variant="primary"
-              class="purchase-button"
-              :mainText="`Buy on Bazaar!`"
-            >
-            </big-button>
-            -->
+              <a :href="marketLink" target="_blank" rel="noopener noreferrer">
+                <big-button
+                variant="primary"
+                class="purchase-button"
+                :mainText="`Buy on Bazaar!`"
+                >
+              </big-button>
+            </a>
           </div>
           <big-button
             v-if="ownerAddress"
@@ -187,6 +181,10 @@ export default Vue.extend({
       'charactersWithIds',
       'ownCharacters',
     ]) as Accessors<StoreMappedGetters>),
+
+    marketLink(): string{
+      return `https://bazaar.market/buy/${this.nftType}?id=${this.nftId}`;
+    },
 
     isKnownNftType(): boolean {
       return isNftType(this.nftType);


### PR DESCRIPTION
See issue #1341 
bazaar supports these links now; added btn with link on the nft display view:
https://github.com/CryptoBlades/marketplace/pull/434


![image](https://user-images.githubusercontent.com/5601589/164816278-897cf3a9-3259-445e-81ca-1b4587c81077.png)
![image](https://user-images.githubusercontent.com/5601589/164816281-3dbb1a6e-e2ca-40c4-a488-411ce8f9f0b3.png)
