### PR TITLE
uncomment clear duel queue function and add migration

### DIFF
--- a/contracts/PvpArena.sol
+++ b/contracts/PvpArena.sol
@@ -1233,17 +1233,17 @@ contract PvpArena is Initializable, AccessControlUpgradeable {
 
     // Note: The following are debugging functions..
 
-    // function clearDuelQueue(uint256 length) external restricted {
-    //     for (uint256 i = 0; i < length; i++) {
-    //         if (matchByFinder[_duelQueue.at(i)].defenderID > 0) {
-    //             isDefending[matchByFinder[_duelQueue.at(i)].defenderID] = false;
-    //         }
+    function clearDuelQueue(uint256 length) external restricted {
+        for (uint256 i = 0; i < length; i++) {
+            if (matchByFinder[_duelQueue.at(i)].defenderID > 0) {
+                isDefending[matchByFinder[_duelQueue.at(i)].defenderID] = false;
+            }
 
-    //         _duelQueue.remove(_duelQueue.at(i));
-    //     }
+            _duelQueue.remove(_duelQueue.at(i));
+        }
 
-    //     isDefending[0] = false;
-    // }
+        isDefending[0] = false;
+    }
 
     // Note: Unmute this to test ranking interactions 
     

--- a/migrations/165_pvp_arena_clear_queue.js
+++ b/migrations/165_pvp_arena_clear_queue.js
@@ -1,0 +1,8 @@
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+
+const PvpArena = artifacts.require("PvpArena");
+
+module.exports = async function (deployer, network) {
+
+    const pvp = await upgradeProxy(PvpArena.address, PvpArena, { deployer });
+};


### PR DESCRIPTION
This PR:

- Restores the "clearDuelQueue" method.