### PR TITLE
Add wallet connect

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,8 +69,7 @@
     "@babel/compat-data": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
-      "dev": true
+      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog=="
     },
     "@babel/core": {
       "version": "7.13.8",
@@ -100,7 +99,6 @@
       "version": "7.13.9",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
       "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
@@ -130,7 +128,6 @@
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
       "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
@@ -165,7 +162,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
       "integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
-      "dev": true,
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
         "@babel/helper-module-imports": "^7.12.13",
@@ -190,7 +186,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
       "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.12.13",
         "@babel/template": "^7.12.13",
@@ -201,7 +196,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
       "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
       }
@@ -229,7 +223,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
       "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
       }
@@ -263,8 +256,7 @@
     "@babel/helper-plugin-utils": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
-      "dev": true
+      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.13.0",
@@ -311,7 +303,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
       "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
       }
@@ -324,8 +315,7 @@
     "@babel/helper-validator-option": {
       "version": "7.12.17",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
-      "dev": true
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.13.0",
@@ -363,8 +353,7 @@
     "@babel/parser": {
       "version": "7.13.9",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
-      "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
-      "dev": true
+      "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.13.8",
@@ -917,7 +906,6 @@
       "version": "7.13.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.9.tgz",
       "integrity": "sha512-XCxkY/wBI6M6Jj2mlWxkmqbKPweRanszWbF3Tyut+hKh+PHcuIH/rSr/7lmmE7C3WW+HSIm2GT+d5jwmheuB0g==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.12.13",
         "@babel/helper-plugin-utils": "^7.13.0",
@@ -931,7 +919,6 @@
           "version": "0.1.10",
           "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz",
           "integrity": "sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==",
-          "dev": true,
           "requires": {
             "@babel/compat-data": "^7.13.0",
             "@babel/helper-define-polyfill-provider": "^0.1.5",
@@ -942,7 +929,6 @@
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
           "integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
-          "dev": true,
           "requires": {
             "@babel/helper-define-polyfill-provider": "^0.1.5",
             "core-js-compat": "^3.8.1"
@@ -952,7 +938,6 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz",
           "integrity": "sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==",
-          "dev": true,
           "requires": {
             "@babel/helper-define-polyfill-provider": "^0.1.5"
           }
@@ -1273,7 +1258,6 @@
       "version": "7.13.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
       "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1282,7 +1266,6 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
       "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/parser": "^7.12.13",
@@ -1293,7 +1276,6 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
       "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.0",
@@ -1310,7 +1292,6 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
       "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
@@ -1321,6 +1302,68 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@chenfengyuan/vue-countdown/-/vue-countdown-1.1.5.tgz",
       "integrity": "sha512-BB0taTfJzxsXFUPioREWLKpMDdHOoD8EiSW6lhB3yCdJh3I7jiNQzC8Hw5dPxoPNgZekeEPMQwsdPkjQPyxIeA=="
+    },
+    "@ethereumjs/common": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.4.tgz",
+      "integrity": "sha512-RDJh/R/EAr+B7ZRg5LfJ0BIpf/1LydFgYdvZEuTraojCbVypO2sQ+QnpP5u2wJf9DASyooKqu8O4FJEWUV6NXw==",
+      "requires": {
+        "crc-32": "^1.2.0",
+        "ethereumjs-util": "^7.1.4"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          }
+        }
+      }
+    },
+    "@ethereumjs/tx": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.1.tgz",
+      "integrity": "sha512-xzDrTiu4sqZXUcaBxJ4n4W5FrppwxLxZB4ZDGVLtxSQR4lVuOnFR6RcUHdg1mpUhAPVrmnzLJpxaeXnPxIyhWA==",
+      "requires": {
+        "@ethereumjs/common": "^2.6.3",
+        "ethereumjs-util": "^7.1.4"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          }
+        }
+      }
     },
     "@ethersproject/abi": {
       "version": "5.0.7",
@@ -1590,6 +1633,11 @@
       "requires": {
         "bowser": "^2.9.0"
       }
+    },
+    "@metamask/safe-event-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -2138,9 +2186,9 @@
       "dev": true
     },
     "@types/secp256k1": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-      "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
       "requires": {
         "@types/node": "*"
       }
@@ -4583,6 +4631,220 @@
       "integrity": "sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==",
       "dev": true
     },
+    "@walletconnect/browser-utils": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.8.tgz",
+      "integrity": "sha512-iCL0XCWOZaABIc0lqA79Vyaybr3z26nt8mxiwvfrG8oaKUf5Y21Of4dj+wIXQ4Hhblre6SgDlU0Ffb39+1THOw==",
+      "requires": {
+        "@walletconnect/safe-json": "1.0.0",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/window-getters": "1.0.0",
+        "@walletconnect/window-metadata": "1.0.0",
+        "detect-browser": "5.2.0"
+      }
+    },
+    "@walletconnect/client": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.7.8.tgz",
+      "integrity": "sha512-pBroM6jZAaUM0SoXJZg5U7aPTiU3ljQAw3Xh/i2pxFDeN/oPKao7husZ5rdxS5xuGSV6YpqqRb0RxW1IeoR2Pg==",
+      "requires": {
+        "@walletconnect/core": "^1.7.8",
+        "@walletconnect/iso-crypto": "^1.7.8",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
+      }
+    },
+    "@walletconnect/core": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.8.tgz",
+      "integrity": "sha512-9xcQ0YNf9JUFb0YOX1Mpy4Yojt+6w2yQz/0aIEyj2X/s9D71NW0fTYsMcdhkLOI7mn2cqVbx2t1lRvdgqsbrSQ==",
+      "requires": {
+        "@walletconnect/socket-transport": "^1.7.8",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
+      }
+    },
+    "@walletconnect/crypto": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.2.tgz",
+      "integrity": "sha512-+OlNtwieUqVcOpFTvLBvH+9J9pntEqH5evpINHfVxff1XIgwV55PpbdvkHu6r9Ib4WQDOFiD8OeeXs1vHw7xKQ==",
+      "requires": {
+        "@walletconnect/encoding": "^1.0.1",
+        "@walletconnect/environment": "^1.0.0",
+        "@walletconnect/randombytes": "^1.0.2",
+        "aes-js": "^3.1.2",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "@walletconnect/encoding": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.1.tgz",
+      "integrity": "sha512-8opL2rs6N6E3tJfsqwS82aZQDL3gmupWUgmvuZ3CGU7z/InZs3R9jkzH8wmYtpbq0sFK3WkJkQRZFFk4BkrmFA==",
+      "requires": {
+        "is-typedarray": "1.0.0",
+        "typedarray-to-buffer": "3.1.5"
+      }
+    },
+    "@walletconnect/environment": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.0.tgz",
+      "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
+    },
+    "@walletconnect/http-connection": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/http-connection/-/http-connection-1.7.8.tgz",
+      "integrity": "sha512-31gjBw46MRU9hFMTNXAqh+f8qpDNzVeV9BJehzVWKiNC3ciL1JCZkbvsY0djwajduE6TB2ujaML0XDXS9HgBRA==",
+      "requires": {
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8",
+        "eventemitter3": "4.0.7",
+        "xhr2-cookies": "1.1.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        }
+      }
+    },
+    "@walletconnect/iso-crypto": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.8.tgz",
+      "integrity": "sha512-Qo6qDcMG0Ac+9fpWE0h/oE55NHLk6eM2vlXpWlQDN/me7RZGrkvk+LXsAkQ3UiYPEiPfq4eswcyRWC9AcrAscg==",
+      "requires": {
+        "@walletconnect/crypto": "^1.0.2",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8"
+      }
+    },
+    "@walletconnect/jsonrpc-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.0.tgz",
+      "integrity": "sha512-11QXNq5H1PKZk7bP8SxgmCw3HRaDuPOVE+wObqEvmhc7OWYUZqfuaaMb+OXGRSOHL3sbC+XHfdeCxFTMXSFyng==",
+      "requires": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "@walletconnect/jsonrpc-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.0.tgz",
+      "integrity": "sha512-qUHbKUK6sHeHn67qtHZoLoYk5hS6x1arTPjKDRkY93/6Fx+ZmNIpdm1owX3l6aYueyegJ7mz43FpvYHUqJ8xcw==",
+      "requires": {
+        "@walletconnect/environment": "^1.0.0",
+        "@walletconnect/jsonrpc-types": "^1.0.0"
+      }
+    },
+    "@walletconnect/mobile-registry": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-1.4.0.tgz",
+      "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw=="
+    },
+    "@walletconnect/qrcode-modal": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.7.8.tgz",
+      "integrity": "sha512-LqNJMLWO+ljvoRSdq8tcEslW0imKrrb+ugs3bw4w/jEI1FSJzVeinEsgVpyaMv8wsUcyTcSCXSkXpT1SXHtcpw==",
+      "requires": {
+        "@walletconnect/browser-utils": "^1.7.8",
+        "@walletconnect/mobile-registry": "^1.4.0",
+        "@walletconnect/types": "^1.7.8",
+        "copy-to-clipboard": "^3.3.1",
+        "preact": "10.4.1",
+        "qrcode": "1.4.4"
+      }
+    },
+    "@walletconnect/randombytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.2.tgz",
+      "integrity": "sha512-ivgOtAyqQnN0rLQmOFPemsgYGysd/ooLfaDA/ACQ3cyqlca56t3rZc7pXfqJOIETx/wSyoF5XbwL+BqYodw27A==",
+      "requires": {
+        "@walletconnect/encoding": "^1.0.1",
+        "@walletconnect/environment": "^1.0.0",
+        "randombytes": "^2.1.0"
+      }
+    },
+    "@walletconnect/safe-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
+      "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
+    },
+    "@walletconnect/socket-transport": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.8.tgz",
+      "integrity": "sha512-bqEjLxfSzG79v2OT7XVOZoyUkg6g3yng0fURrdLusWs42fYHWnrSrIZDejFn8N5PiZk5R2edrggkQ7w0VUUAfw==",
+      "requires": {
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8",
+        "ws": "7.5.3"
+      }
+    },
+    "@walletconnect/types": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.8.tgz",
+      "integrity": "sha512-0oSZhKIrtXRJVP1jQ0EDTRtotQY6kggGjDcmm/LLQBKnOZXdPeo0sPkV/7DjT5plT3O7Cjc6JvuXt9WOY0hlCA=="
+    },
+    "@walletconnect/utils": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
+      "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
+      "requires": {
+        "@walletconnect/browser-utils": "^1.7.8",
+        "@walletconnect/encoding": "^1.0.1",
+        "@walletconnect/jsonrpc-utils": "^1.0.0",
+        "@walletconnect/types": "^1.7.8",
+        "bn.js": "4.11.8",
+        "js-sha3": "0.8.0",
+        "query-string": "6.13.5"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "query-string": {
+          "version": "6.13.5",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
+          "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+        }
+      }
+    },
+    "@walletconnect/web3-provider": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/web3-provider/-/web3-provider-1.7.8.tgz",
+      "integrity": "sha512-2VxGo7KPfQTWRJ+rygt3ok/u04InkVE+H9LBIF/RMUwcwyGf2nsP3CcYZVcg3yYpacgN7bAZCersCEYwU8AeeA==",
+      "requires": {
+        "@walletconnect/client": "^1.7.8",
+        "@walletconnect/http-connection": "^1.7.8",
+        "@walletconnect/qrcode-modal": "^1.7.8",
+        "@walletconnect/types": "^1.7.8",
+        "@walletconnect/utils": "^1.7.8",
+        "web3-provider-engine": "16.0.1"
+      }
+    },
+    "@walletconnect/window-getters": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.0.tgz",
+      "integrity": "sha512-xB0SQsLaleIYIkSsl43vm8EwETpBzJ2gnzk7e0wMF3ktqiTGS6TFHxcprMl5R44KKh4tCcHCJwolMCaDSwtAaA=="
+    },
+    "@walletconnect/window-metadata": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.0.tgz",
+      "integrity": "sha512-9eFvmJxIKCC3YWOL97SgRkKhlyGXkrHwamfechmqszbypFspaSk+t2jQXAEU7YClHF6Qjw5eYOmy1//zFi9/GA==",
+      "requires": {
+        "@walletconnect/window-getters": "^1.0.0"
+      }
+    },
     "@waxio/waxjs": {
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/@waxio/waxjs/-/waxjs-0.0.15.tgz",
@@ -4787,6 +5049,14 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "abstract-leveldown": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+      "requires": {
+        "xtend": "~4.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -4819,6 +5089,11 @@
       "resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
       "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
       "dev": true
+    },
+    "aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -4922,8 +5197,7 @@
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -5359,7 +5633,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -5370,10 +5643,33 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
+    "async-eventemitter": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+      "requires": {
+        "async": "^2.4.0"
+      }
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "async-mutex": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.2.6.tgz",
+      "integrity": "sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
     },
     "async-retry": {
       "version": "1.3.3",
@@ -5629,6 +5925,14 @@
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5771,9 +6075,9 @@
       }
     },
     "blakejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
-      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -6060,7 +6364,6 @@
       "version": "4.16.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
       "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001251",
         "colorette": "^1.3.0",
@@ -6087,11 +6390,15 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+    },
     "buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -6101,7 +6408,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -6110,8 +6416,7 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -6122,14 +6427,12 @@
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -6437,8 +6740,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -6455,8 +6757,7 @@
     "caniuse-lite": {
       "version": "1.0.30001251",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
-      "dev": true
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -6508,6 +6809,14 @@
       "integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
       "dev": true
     },
+    "checkpoint-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
+      "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
+      "requires": {
+        "functional-red-black-tree": "^1.0.1"
+      }
+    },
     "chokidar": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
@@ -6553,15 +6862,6 @@
         "multihashes": "~0.4.15"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
         "multicodec": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
@@ -6848,8 +7148,7 @@
     "colorette": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
-      "dev": true
+      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
     },
     "colors": {
       "version": "1.4.0",
@@ -7075,6 +7374,14 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "copy-webpack-plugin": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
@@ -7214,7 +7521,6 @@
       "version": "3.16.2",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
       "integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
-      "dev": true,
       "requires": {
         "browserslist": "^4.16.7",
         "semver": "7.0.0"
@@ -7223,8 +7529,7 @@
         "semver": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-          "dev": true
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
         }
       }
     },
@@ -7261,6 +7566,11 @@
         "path-type": "^4.0.0",
         "yaml": "^1.7.2"
       }
+    },
+    "crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -7301,6 +7611,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.6.tgz",
+      "integrity": "sha512-9JZz+vXCmfKUZ68zAptS7k4Nu8e2qcibe7WVZYps7sAgk5R8GYTc+T1WR0v1rlP9HxgARmOX1UTIJZFytajpNA==",
+      "requires": {
+        "node-fetch": "^2.6.7",
+        "whatwg-fetch": "^2.0.4"
       }
     },
     "cross-spawn": {
@@ -7636,7 +7955,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -7644,8 +7962,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -7951,6 +8268,14 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
+    "deferred-leveldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "requires": {
+        "abstract-leveldown": "~2.6.0"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -8098,6 +8423,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
+    },
     "detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -8135,6 +8465,11 @@
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
+    },
+    "dijkstrajs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.2.tgz",
+      "integrity": "sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -8470,8 +8805,7 @@
     "electron-to-chromium": {
       "version": "1.3.814",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
-      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==",
-      "dev": true
+      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -8497,8 +8831,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -8637,7 +8970,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -8743,8 +9075,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -8995,6 +9326,19 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eth-block-tracker": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-4.4.3.tgz",
+      "integrity": "sha512-A8tG4Z4iNg4mw5tP1Vung9N9IjgMNqpiMoJ/FouSFwNCGHv2X0mmOYwtQOJzki6XN7r7Tyo01S29p7b224I4jw==",
+      "requires": {
+        "@babel/plugin-transform-runtime": "^7.5.5",
+        "@babel/runtime": "^7.5.5",
+        "eth-query": "^2.1.0",
+        "json-rpc-random-id": "^1.0.1",
+        "pify": "^3.0.0",
+        "safe-event-emitter": "^1.0.1"
+      }
+    },
     "eth-ens-namehash": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
@@ -9008,6 +9352,82 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "eth-json-rpc-filters": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.2.2.tgz",
+      "integrity": "sha512-DGtqpLU7bBg63wPMWg1sCpkKCf57dJ+hj/k3zF26anXMzkmtSBDExL8IhUu7LUd34f0Zsce3PYNO2vV2GaTzaw==",
+      "requires": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "async-mutex": "^0.2.6",
+        "eth-json-rpc-middleware": "^6.0.0",
+        "eth-query": "^2.1.2",
+        "json-rpc-engine": "^6.1.0",
+        "pify": "^5.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+        }
+      }
+    },
+    "eth-json-rpc-infura": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-5.1.0.tgz",
+      "integrity": "sha512-THzLye3PHUSGn1EXMhg6WTLW9uim7LQZKeKaeYsS9+wOBcamRiCQVGHa6D2/4P0oS0vSaxsBnU/J6qvn0MPdow==",
+      "requires": {
+        "eth-json-rpc-middleware": "^6.0.0",
+        "eth-rpc-errors": "^3.0.0",
+        "json-rpc-engine": "^5.3.0",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "json-rpc-engine": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
+          "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
+          "requires": {
+            "eth-rpc-errors": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        }
+      }
+    },
+    "eth-json-rpc-middleware": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-6.0.0.tgz",
+      "integrity": "sha512-qqBfLU2Uq1Ou15Wox1s+NX05S9OcAEL4JZ04VZox2NS0U+RtCMjSxzXhLFWekdShUPZ+P8ax3zCO2xcPrp6XJQ==",
+      "requires": {
+        "btoa": "^1.2.1",
+        "clone": "^2.1.1",
+        "eth-query": "^2.1.2",
+        "eth-rpc-errors": "^3.0.0",
+        "eth-sig-util": "^1.4.2",
+        "ethereumjs-util": "^5.1.2",
+        "json-rpc-engine": "^5.3.0",
+        "json-stable-stringify": "^1.0.1",
+        "node-fetch": "^2.6.1",
+        "pify": "^3.0.0",
+        "safe-event-emitter": "^1.0.1"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "json-rpc-engine": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
+          "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
+          "requires": {
+            "eth-rpc-errors": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
         }
       }
     },
@@ -9041,6 +9461,32 @@
         }
       }
     },
+    "eth-query": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+      "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
+      "requires": {
+        "json-rpc-random-id": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "eth-rpc-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-3.0.0.tgz",
+      "integrity": "sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==",
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
+    "eth-sig-util": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+      "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
+      "requires": {
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-util": "^5.1.1"
+      }
+    },
     "ethereum-bloom-filters": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
@@ -9048,6 +9494,11 @@
       "requires": {
         "js-sha3": "^0.8.0"
       }
+    },
+    "ethereum-common": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
     },
     "ethereum-cryptography": {
       "version": "0.1.3",
@@ -9071,38 +9522,172 @@
         "setimmediate": "^1.0.5"
       }
     },
-    "ethereumjs-common": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
-    },
-    "ethereumjs-tx": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+    "ethereumjs-abi": {
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
-        "ethereumjs-common": "^1.5.0",
+        "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
-      }
-    },
-    "ethereumjs-util": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-      "requires": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
       },
       "dependencies": {
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        }
+      }
+    },
+    "ethereumjs-account": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
+      "requires": {
+        "ethereumjs-util": "^5.0.0",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "ethereumjs-block": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+      "requires": {
+        "async": "^2.0.1",
+        "ethereum-common": "0.2.0",
+        "ethereumjs-tx": "^1.2.2",
+        "ethereumjs-util": "^5.0.0",
+        "merkle-patricia-tree": "^2.1.2"
+      }
+    },
+    "ethereumjs-common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
+      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
+    },
+    "ethereumjs-tx": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+      "requires": {
+        "ethereum-common": "^0.0.18",
+        "ethereumjs-util": "^5.0.0"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+        }
+      }
+    },
+    "ethereumjs-util": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+      "requires": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "elliptic": "^6.5.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "^0.1.3",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
+    "ethereumjs-vm": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
+      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
+      "requires": {
+        "async": "^2.1.2",
+        "async-eventemitter": "^0.2.2",
+        "ethereumjs-account": "^2.0.3",
+        "ethereumjs-block": "~2.2.0",
+        "ethereumjs-common": "^1.1.0",
+        "ethereumjs-util": "^6.0.0",
+        "fake-merkle-patricia-tree": "^1.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "merkle-patricia-tree": "^2.3.2",
+        "rustbn.js": "~0.2.0",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ethereumjs-block": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+          "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
+          "requires": {
+            "async": "^2.0.1",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-tx": "^2.1.1",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
         }
       }
     },
@@ -9146,8 +9731,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "eventsource": {
       "version": "1.1.0",
@@ -9537,6 +10121,14 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fake-merkle-patricia-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
+      "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
+      "requires": {
+        "checkpoint-store": "^1.1.0"
+      }
+    },
     "fantastical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fantastical/-/fantastical-2.0.1.tgz",
@@ -9584,6 +10176,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastq": {
       "version": "1.12.0",
@@ -9758,7 +10355,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -10100,8 +10696,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "generate-function": {
       "version": "1.1.0",
@@ -10127,8 +10722,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -10247,8 +10841,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "11.0.4",
@@ -11005,6 +11598,11 @@
         }
       }
     },
+    "immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -11371,7 +11969,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
       "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -11443,11 +12040,15 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
+    "is-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-function": {
       "version": "1.0.2",
@@ -11691,8 +12292,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "4.0.8",
@@ -11973,8 +12573,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "jshint": {
       "version": "2.13.1",
@@ -12077,6 +12676,30 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "json-rpc-engine": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+      "requires": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "eth-rpc-errors": "^4.0.2"
+      },
+      "dependencies": {
+        "eth-rpc-errors": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+          "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
+        }
+      }
+    },
+    "json-rpc-random-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg="
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -12086,6 +12709,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -12120,6 +12751,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -12167,6 +12803,11 @@
         "json-buffer": "3.0.0"
       }
     },
+    "keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -12202,6 +12843,119 @@
       "dev": true,
       "requires": {
         "launch-editor": "^2.2.1"
+      }
+    },
+    "level-codec": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+    },
+    "level-errors": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "requires": {
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "level-errors": "^1.0.3",
+        "readable-stream": "^1.0.33",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "level-ws": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+      "requires": {
+        "readable-stream": "~1.0.15",
+        "xtend": "~2.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
+    },
+    "levelup": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "requires": {
+        "deferred-leveldown": "~1.2.1",
+        "level-codec": "~7.0.0",
+        "level-errors": "~1.0.3",
+        "level-iterator-stream": "~1.3.0",
+        "prr": "~1.0.1",
+        "semver": "~5.4.1",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        }
       }
     },
     "leven": {
@@ -12308,7 +13062,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -12333,8 +13086,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
@@ -12461,6 +13213,11 @@
         }
       }
     },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -12504,6 +13261,29 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memdown": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "requires": {
+        "abstract-leveldown": "~2.7.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        }
+      }
     },
     "memfs": {
       "version": "3.4.1",
@@ -12563,6 +13343,28 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "merkle-patricia-tree": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
+      "requires": {
+        "async": "^1.4.2",
+        "ethereumjs-util": "^5.0.0",
+        "level-ws": "0.0.0",
+        "levelup": "^1.2.1",
+        "memdown": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "rlp": "^2.0.0",
+        "semaphore": ">=1.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
     },
     "methods": {
       "version": "1.1.2",
@@ -12860,8 +13662,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multibase": {
       "version": "0.6.1",
@@ -12870,17 +13671,6 @@
       "requires": {
         "base-x": "^3.0.8",
         "buffer": "^5.5.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
       }
     },
     "multicast-dns": {
@@ -12917,15 +13707,6 @@
         "varint": "^5.0.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
         "multibase": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
@@ -13215,8 +13996,7 @@
     "node-releases": {
       "version": "1.1.75",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
-      "dev": true
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
     },
     "noms": {
       "version": "0.0.0",
@@ -13657,7 +14437,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -13666,7 +14445,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -13713,8 +14491,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
       "version": "1.0.11",
@@ -13843,8 +14620,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -13866,8 +14642,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -13969,8 +14744,7 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -14004,6 +14778,11 @@
       "requires": {
         "find-up": "^3.0.0"
       }
+    },
+    "pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
     "pnp-webpack-plugin": {
       "version": "1.7.0",
@@ -14680,6 +15459,16 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
+    "preact": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.1.tgz",
+      "integrity": "sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q=="
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -14737,8 +15526,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -14751,6 +15539,15 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
+    },
+    "promise-to-callback": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
+      "requires": {
+        "is-fn": "^1.0.0",
+        "set-immediate-shim": "^1.0.1"
+      }
     },
     "proto-list": {
       "version": "1.2.4",
@@ -14770,8 +15567,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "ps-list": {
       "version": "4.1.0",
@@ -14856,6 +15652,96 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
+    },
+    "qrcode": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.4.tgz",
+      "integrity": "sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==",
+      "requires": {
+        "buffer": "^5.4.3",
+        "buffer-alloc": "^1.2.0",
+        "buffer-from": "^1.1.1",
+        "dijkstrajs": "^1.0.1",
+        "isarray": "^2.0.1",
+        "pngjs": "^3.3.0",
+        "yargs": "^13.2.4"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "qs": {
       "version": "6.7.0",
@@ -14945,7 +15831,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -15223,14 +16108,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "requires-port": {
       "version": "1.0.0",
@@ -15242,7 +16125,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -15342,18 +16224,11 @@
       }
     },
     "rlp": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
       "requires": {
-        "bn.js": "^4.11.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
+        "bn.js": "^5.2.0"
       }
     },
     "rss-parser": {
@@ -15389,6 +16264,11 @@
         "aproba": "^1.1.1"
       }
     },
+    "rustbn.js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
+    },
     "rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -15402,6 +16282,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-event-emitter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
+      "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
+      "requires": {
+        "events": "^3.0.0"
+      }
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -15498,11 +16386,11 @@
       "dev": true
     },
     "secp256k1": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
       "requires": {
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.4",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }
@@ -15535,6 +16423,11 @@
       "requires": {
         "node-forge": "^0.10.0"
       }
+    },
+    "semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
     "semver": {
       "version": "6.3.0",
@@ -15679,8 +16572,12 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.1",
@@ -16015,8 +16912,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -16126,6 +17022,11 @@
           }
         }
       }
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -16495,15 +17396,6 @@
         "xhr-request": "^1.0.1"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
         "fs-extra": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
@@ -16997,8 +17889,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -17045,6 +17936,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -18125,34 +19021,205 @@
       }
     },
     "web3": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.4.tgz",
-      "integrity": "sha512-D6cMb2EtTMLHgdGbkTPGl/Qi7DAfczR+Lp7iFX3bcu/bsD9V8fZW69hA8v5cRPNGzXUwVQebk3bS17WKR4cD2w==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.7.3.tgz",
+      "integrity": "sha512-UgBvQnKIXncGYzsiGacaiHtm0xzQ/JtGqcSO/ddzQHYxnNuwI72j1Pb4gskztLYihizV9qPNQYHMSCiBlStI9A==",
       "requires": {
-        "web3-bzz": "1.3.4",
-        "web3-core": "1.3.4",
-        "web3-eth": "1.3.4",
-        "web3-eth-personal": "1.3.4",
-        "web3-net": "1.3.4",
-        "web3-shh": "1.3.4",
-        "web3-utils": "1.3.4"
-      }
-    },
-    "web3-bzz": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.4.tgz",
-      "integrity": "sha512-DBRVQB8FAgoAtZCpp2GAGPCJjgBgsuwOKEasjV044AAZiONpXcKHbkO6G1SgItIixnrJsRJpoGLGw52Byr6FKw==",
-      "requires": {
-        "@types/node": "^12.12.6",
-        "got": "9.6.0",
-        "swarm-js": "^0.1.40",
-        "underscore": "1.9.1"
+        "web3-bzz": "1.7.3",
+        "web3-core": "1.7.3",
+        "web3-eth": "1.7.3",
+        "web3-eth-personal": "1.7.3",
+        "web3-net": "1.7.3",
+        "web3-shh": "1.7.3",
+        "web3-utils": "1.7.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.20",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.20.tgz",
-          "integrity": "sha512-kqmxiJg4AT7rsSPIhO6eoBIx9mNwwpeH42yjtgQh6X2ANSpLpvToMXv+LMFdfxpwG1FZXZ41OGZMiUAtbBLEvg=="
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "bn.js": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "util": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "web3-core": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
+          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-requestmanager": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
+          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
+          "requires": {
+            "web3-eth-iban": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
+          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
+          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
+          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
+          "requires": {
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-providers-http": "1.7.3",
+            "web3-providers-ipc": "1.7.3",
+            "web3-providers-ws": "1.7.3"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
+          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
+          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
+          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
+          "requires": {
+            "web3-core-helpers": "1.7.3",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
+          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
+          "requires": {
+            "oboe": "2.1.5",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
+          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-utils": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
+          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-bzz": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.7.3.tgz",
+      "integrity": "sha512-y2i2IW0MfSqFc1JBhBSQ59Ts9xE30hhxSmLS13jLKWzie24/An5dnoGarp2rFAy20tevJu1zJVPYrEl14jiL5w==",
+      "requires": {
+        "@types/node": "^12.12.6",
+        "got": "9.6.0",
+        "swarm-js": "^0.1.40"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
         }
       }
     },
@@ -18261,23 +19328,218 @@
       }
     },
     "web3-eth": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.4.tgz",
-      "integrity": "sha512-8OIVMLbvmx+LB5RZ4tDhXuFGWSdNMrCZ4HM0+PywQ08uEcmAcqTMFAn4vdPii+J8gCatZR501r1KdzX3SDLoPw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.7.3.tgz",
+      "integrity": "sha512-BCIRMPwaMlTCbswXyGT6jj9chCh9RirbDFkPtvqozfQ73HGW7kP78TXXf9+Xdo1GjutQfxi/fQ9yPdxtDJEpDA==",
       "requires": {
-        "underscore": "1.9.1",
-        "web3-core": "1.3.4",
-        "web3-core-helpers": "1.3.4",
-        "web3-core-method": "1.3.4",
-        "web3-core-subscriptions": "1.3.4",
-        "web3-eth-abi": "1.3.4",
-        "web3-eth-accounts": "1.3.4",
-        "web3-eth-contract": "1.3.4",
-        "web3-eth-ens": "1.3.4",
-        "web3-eth-iban": "1.3.4",
-        "web3-eth-personal": "1.3.4",
-        "web3-net": "1.3.4",
-        "web3-utils": "1.3.4"
+        "web3-core": "1.7.3",
+        "web3-core-helpers": "1.7.3",
+        "web3-core-method": "1.7.3",
+        "web3-core-subscriptions": "1.7.3",
+        "web3-eth-abi": "1.7.3",
+        "web3-eth-accounts": "1.7.3",
+        "web3-eth-contract": "1.7.3",
+        "web3-eth-ens": "1.7.3",
+        "web3-eth-iban": "1.7.3",
+        "web3-eth-personal": "1.7.3",
+        "web3-net": "1.7.3",
+        "web3-utils": "1.7.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "bn.js": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "util": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "web3-core": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
+          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-requestmanager": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
+          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
+          "requires": {
+            "web3-eth-iban": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
+          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
+          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
+          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
+          "requires": {
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-providers-http": "1.7.3",
+            "web3-providers-ipc": "1.7.3",
+            "web3-providers-ws": "1.7.3"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
+          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.3.tgz",
+          "integrity": "sha512-ZlD8DrJro0ocnbZViZpAoMX44x5aYAb73u2tMq557rMmpiluZNnhcCYF/NnVMy6UIkn7SF/qEA45GXA1ne6Tnw==",
+          "requires": {
+            "@ethersproject/abi": "5.0.7",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.3.tgz",
+          "integrity": "sha512-7mjkLxCNMWlQrlfM/MmNnlKRHwFk5XrZcbndoMt3KejcqDP6dPHi2PZLutEcw07n/Sk8OMpSamyF3QiGfmyRxw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "web3-core": "1.7.3",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-eth-abi": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
+          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
+          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
+          "requires": {
+            "web3-core-helpers": "1.7.3",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
+          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
+          "requires": {
+            "oboe": "2.1.5",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
+          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-utils": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
+          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-abi": {
@@ -18291,23 +19553,31 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.4.tgz",
-      "integrity": "sha512-gz9ReSmQEjqbYAjpmAx+UZF4CVMbyS4pfjSYWGAnNNI+Xz0f0u0kCIYXQ1UEaE+YeLcYiE+ZlZdgg6YoatO5nA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.7.3.tgz",
+      "integrity": "sha512-aDaWjW1oJeh0LeSGRVyEBiTe/UD2/cMY4dD6pQYa8dOhwgMtNQjxIQ7kacBBXe7ZKhjbIFZDhvXN4mjXZ82R2Q==",
       "requires": {
+        "@ethereumjs/common": "^2.5.0",
+        "@ethereumjs/tx": "^3.3.2",
         "crypto-browserify": "3.12.0",
         "eth-lib": "0.2.8",
-        "ethereumjs-common": "^1.3.2",
-        "ethereumjs-tx": "^2.1.1",
+        "ethereumjs-util": "^7.0.10",
         "scrypt-js": "^3.0.1",
-        "underscore": "1.9.1",
         "uuid": "3.3.2",
-        "web3-core": "1.3.4",
-        "web3-core-helpers": "1.3.4",
-        "web3-core-method": "1.3.4",
-        "web3-utils": "1.3.4"
+        "web3-core": "1.7.3",
+        "web3-core-helpers": "1.7.3",
+        "web3-core-method": "1.7.3",
+        "web3-utils": "1.7.3"
       },
       "dependencies": {
+        "@types/bn.js": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -18323,10 +19593,177 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "util": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3-core": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
+          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-requestmanager": "1.7.3",
+            "web3-utils": "1.7.3"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "@types/node": {
+              "version": "12.20.52",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+              "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
+            }
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
+          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
+          "requires": {
+            "web3-eth-iban": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
+          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
+          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
+          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
+          "requires": {
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-providers-http": "1.7.3",
+            "web3-providers-ipc": "1.7.3",
+            "web3-providers-ws": "1.7.3"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
+          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
+          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
+          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
+          "requires": {
+            "web3-core-helpers": "1.7.3",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
+          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
+          "requires": {
+            "oboe": "2.1.5",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
+          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-utils": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
+          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
@@ -18347,19 +19784,214 @@
       }
     },
     "web3-eth-ens": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.4.tgz",
-      "integrity": "sha512-b0580tQyQwpV2wyacwQiBEfQmjCUln5iPhge3IBIMXaI43BUNtH3lsCL9ERFQeOdweB4o+6rYyNYr6xbRcSytg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.7.3.tgz",
+      "integrity": "sha512-q7+hFGHIc0mBI3LwgRVcLCQmp6GItsWgUtEZ5bjwdjOnJdbjYddm7PO9RDcTDQ6LIr7hqYaY4WTRnDHZ6BEt5Q==",
       "requires": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
-        "underscore": "1.9.1",
-        "web3-core": "1.3.4",
-        "web3-core-helpers": "1.3.4",
-        "web3-core-promievent": "1.3.4",
-        "web3-eth-abi": "1.3.4",
-        "web3-eth-contract": "1.3.4",
-        "web3-utils": "1.3.4"
+        "web3-core": "1.7.3",
+        "web3-core-helpers": "1.7.3",
+        "web3-core-promievent": "1.7.3",
+        "web3-eth-abi": "1.7.3",
+        "web3-eth-contract": "1.7.3",
+        "web3-utils": "1.7.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "bn.js": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "util": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "web3-core": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
+          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-requestmanager": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
+          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
+          "requires": {
+            "web3-eth-iban": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
+          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
+          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
+          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
+          "requires": {
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-providers-http": "1.7.3",
+            "web3-providers-ipc": "1.7.3",
+            "web3-providers-ws": "1.7.3"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
+          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.3.tgz",
+          "integrity": "sha512-ZlD8DrJro0ocnbZViZpAoMX44x5aYAb73u2tMq557rMmpiluZNnhcCYF/NnVMy6UIkn7SF/qEA45GXA1ne6Tnw==",
+          "requires": {
+            "@ethersproject/abi": "5.0.7",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.3.tgz",
+          "integrity": "sha512-7mjkLxCNMWlQrlfM/MmNnlKRHwFk5XrZcbndoMt3KejcqDP6dPHi2PZLutEcw07n/Sk8OMpSamyF3QiGfmyRxw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "web3-core": "1.7.3",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-eth-abi": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
+          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
+          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
+          "requires": {
+            "web3-core-helpers": "1.7.3",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
+          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
+          "requires": {
+            "oboe": "2.1.5",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
+          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-utils": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
+          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-iban": {
@@ -18379,33 +20011,414 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.4.tgz",
-      "integrity": "sha512-JiTbaktYVk1j+S2EDooXAhw5j/VsdvZfKRmHtXUe/HizPM9ETXmj1+ne4RT6m+950jQ7DJwUF3XU1FKYNtEDwQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.7.3.tgz",
+      "integrity": "sha512-iTLz2OYzEsJj2qGE4iXC1Gw+KZN924fTAl0ESBFs2VmRhvVaM7GFqZz/wx7/XESl3GVxGxlRje3gNK0oGIoYYQ==",
       "requires": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.3.4",
-        "web3-core-helpers": "1.3.4",
-        "web3-core-method": "1.3.4",
-        "web3-net": "1.3.4",
-        "web3-utils": "1.3.4"
+        "web3-core": "1.7.3",
+        "web3-core-helpers": "1.7.3",
+        "web3-core-method": "1.7.3",
+        "web3-net": "1.7.3",
+        "web3-utils": "1.7.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.20",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.20.tgz",
-          "integrity": "sha512-kqmxiJg4AT7rsSPIhO6eoBIx9mNwwpeH42yjtgQh6X2ANSpLpvToMXv+LMFdfxpwG1FZXZ41OGZMiUAtbBLEvg=="
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "bn.js": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "util": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "web3-core": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
+          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-requestmanager": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
+          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
+          "requires": {
+            "web3-eth-iban": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
+          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
+          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
+          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
+          "requires": {
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-providers-http": "1.7.3",
+            "web3-providers-ipc": "1.7.3",
+            "web3-providers-ws": "1.7.3"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
+          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
+          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
+          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
+          "requires": {
+            "web3-core-helpers": "1.7.3",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
+          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
+          "requires": {
+            "oboe": "2.1.5",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
+          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-utils": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
+          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-net": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.4.tgz",
-      "integrity": "sha512-wVyqgVC3Zt/0uGnBiR3GpnsS8lvOFTDgWZMxAk9C6Guh8aJD9MUc7pbsw5rHrPUVe6S6RUfFJvh/Xq8oMIQgSw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.7.3.tgz",
+      "integrity": "sha512-zAByK0Qrr71k9XW0Adtn+EOuhS9bt77vhBO6epAeQ2/VKl8rCGLAwrl3GbeEl7kWa8s/su72cjI5OetG7cYR0g==",
       "requires": {
-        "web3-core": "1.3.4",
-        "web3-core-method": "1.3.4",
-        "web3-utils": "1.3.4"
+        "web3-core": "1.7.3",
+        "web3-core-method": "1.7.3",
+        "web3-utils": "1.7.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "bn.js": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "util": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "web3-core": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
+          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-requestmanager": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
+          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
+          "requires": {
+            "web3-eth-iban": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
+          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
+          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
+          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
+          "requires": {
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-providers-http": "1.7.3",
+            "web3-providers-ipc": "1.7.3",
+            "web3-providers-ws": "1.7.3"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
+          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
+          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
+          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
+          "requires": {
+            "web3-core-helpers": "1.7.3",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
+          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
+          "requires": {
+            "oboe": "2.1.5",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
+          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-utils": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
+          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-provider-engine": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-16.0.1.tgz",
+      "integrity": "sha512-/Eglt2aocXMBiDj7Se/lyZnNDaHBaoJlaUfbP5HkLJQC/HlGbR+3/W+dINirlJDhh7b54DzgykqY7ksaU5QgTg==",
+      "requires": {
+        "async": "^2.5.0",
+        "backoff": "^2.5.0",
+        "clone": "^2.0.0",
+        "cross-fetch": "^2.1.0",
+        "eth-block-tracker": "^4.4.2",
+        "eth-json-rpc-filters": "^4.2.1",
+        "eth-json-rpc-infura": "^5.1.0",
+        "eth-json-rpc-middleware": "^6.0.0",
+        "eth-rpc-errors": "^3.0.0",
+        "eth-sig-util": "^1.4.2",
+        "ethereumjs-block": "^1.2.2",
+        "ethereumjs-tx": "^1.2.0",
+        "ethereumjs-util": "^5.1.5",
+        "ethereumjs-vm": "^2.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "promise-to-callback": "^1.0.0",
+        "readable-stream": "^2.2.9",
+        "request": "^2.85.0",
+        "semaphore": "^1.0.3",
+        "ws": "^5.1.1",
+        "xhr": "^2.2.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "ws": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+          "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "web3-providers-http": {
@@ -18446,14 +20459,186 @@
       }
     },
     "web3-shh": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.4.tgz",
-      "integrity": "sha512-zoeww5mxLh3xKcqbX85irQbtFe5pc5XwrgjvmdMkhkOdZzPASlWOgqzUFtaPykpLwC3yavVx4jG5RqifweXLUA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.7.3.tgz",
+      "integrity": "sha512-bQTSKkyG7GkuULdZInJ0osHjnmkHij9tAySibpev1XjYdjLiQnd0J9YGF4HjvxoG3glNROpuCyTaRLrsLwaZuw==",
       "requires": {
-        "web3-core": "1.3.4",
-        "web3-core-method": "1.3.4",
-        "web3-core-subscriptions": "1.3.4",
-        "web3-net": "1.3.4"
+        "web3-core": "1.7.3",
+        "web3-core-method": "1.7.3",
+        "web3-core-subscriptions": "1.7.3",
+        "web3-net": "1.7.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "ethereumjs-util": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
+          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "bn.js": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
+        "util": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "web3-core": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
+          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-method": "1.7.3",
+            "web3-core-requestmanager": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
+          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
+          "requires": {
+            "web3-eth-iban": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
+          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "web3-core-helpers": "1.7.3",
+            "web3-core-promievent": "1.7.3",
+            "web3-core-subscriptions": "1.7.3",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
+          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
+          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
+          "requires": {
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.7.3",
+            "web3-providers-http": "1.7.3",
+            "web3-providers-ipc": "1.7.3",
+            "web3-providers-ws": "1.7.3"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
+          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
+          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.7.3"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
+          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
+          "requires": {
+            "web3-core-helpers": "1.7.3",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
+          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
+          "requires": {
+            "oboe": "2.1.5",
+            "web3-core-helpers": "1.7.3"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
+          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "web3-core-helpers": "1.7.3",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-utils": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
+          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethereumjs-util": "^7.1.0",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-utils": {
@@ -19232,6 +21417,11 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -19265,8 +21455,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "which-typed-array": {
       "version": "1.1.6",
@@ -19438,8 +21627,7 @@
     "ws": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "dev": true
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "xhr": {
       "version": "2.6.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1303,68 +1303,6 @@
       "resolved": "https://registry.npmjs.org/@chenfengyuan/vue-countdown/-/vue-countdown-1.1.5.tgz",
       "integrity": "sha512-BB0taTfJzxsXFUPioREWLKpMDdHOoD8EiSW6lhB3yCdJh3I7jiNQzC8Hw5dPxoPNgZekeEPMQwsdPkjQPyxIeA=="
     },
-    "@ethereumjs/common": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.4.tgz",
-      "integrity": "sha512-RDJh/R/EAr+B7ZRg5LfJ0BIpf/1LydFgYdvZEuTraojCbVypO2sQ+QnpP5u2wJf9DASyooKqu8O4FJEWUV6NXw==",
-      "requires": {
-        "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.4"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          }
-        }
-      }
-    },
-    "@ethereumjs/tx": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.1.tgz",
-      "integrity": "sha512-xzDrTiu4sqZXUcaBxJ4n4W5FrppwxLxZB4ZDGVLtxSQR4lVuOnFR6RcUHdg1mpUhAPVrmnzLJpxaeXnPxIyhWA==",
-      "requires": {
-        "@ethereumjs/common": "^2.6.3",
-        "ethereumjs-util": "^7.1.4"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          }
-        }
-      }
-    },
     "@ethersproject/abi": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
@@ -7566,11 +7504,6 @@
         "path-type": "^4.0.0",
         "yaml": "^1.7.2"
       }
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -19021,199 +18954,28 @@
       }
     },
     "web3": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.7.3.tgz",
-      "integrity": "sha512-UgBvQnKIXncGYzsiGacaiHtm0xzQ/JtGqcSO/ddzQHYxnNuwI72j1Pb4gskztLYihizV9qPNQYHMSCiBlStI9A==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.4.tgz",
+      "integrity": "sha512-D6cMb2EtTMLHgdGbkTPGl/Qi7DAfczR+Lp7iFX3bcu/bsD9V8fZW69hA8v5cRPNGzXUwVQebk3bS17WKR4cD2w==",
       "requires": {
-        "web3-bzz": "1.7.3",
-        "web3-core": "1.7.3",
-        "web3-eth": "1.7.3",
-        "web3-eth-personal": "1.7.3",
-        "web3-net": "1.7.3",
-        "web3-shh": "1.7.3",
-        "web3-utils": "1.7.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          },
-          "dependencies": {
-            "@types/bn.js": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "bn.js": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-            }
-          }
-        },
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        },
-        "web3-core": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
-          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "@types/node": "^12.12.6",
-            "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-requestmanager": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
-          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
-          "requires": {
-            "web3-eth-iban": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
-          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
-          "requires": {
-            "@ethersproject/transactions": "^5.0.0-beta.135",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
-          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
-          "requires": {
-            "eventemitter3": "4.0.4"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
-          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
-          "requires": {
-            "util": "^0.12.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-providers-http": "1.7.3",
-            "web3-providers-ipc": "1.7.3",
-            "web3-providers-ws": "1.7.3"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
-          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
-          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
-          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
-          "requires": {
-            "web3-core-helpers": "1.7.3",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
-          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
-          "requires": {
-            "oboe": "2.1.5",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
-          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3",
-            "websocket": "^1.0.32"
-          }
-        },
-        "web3-utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
-          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethereumjs-util": "^7.1.0",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-bzz": "1.3.4",
+        "web3-core": "1.3.4",
+        "web3-eth": "1.3.4",
+        "web3-eth-personal": "1.3.4",
+        "web3-net": "1.3.4",
+        "web3-shh": "1.3.4",
+        "web3-utils": "1.3.4"
       }
     },
     "web3-bzz": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.7.3.tgz",
-      "integrity": "sha512-y2i2IW0MfSqFc1JBhBSQ59Ts9xE30hhxSmLS13jLKWzie24/An5dnoGarp2rFAy20tevJu1zJVPYrEl14jiL5w==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.4.tgz",
+      "integrity": "sha512-DBRVQB8FAgoAtZCpp2GAGPCJjgBgsuwOKEasjV044AAZiONpXcKHbkO6G1SgItIixnrJsRJpoGLGw52Byr6FKw==",
       "requires": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
-        "swarm-js": "^0.1.40"
+        "swarm-js": "^0.1.40",
+        "underscore": "1.9.1"
       },
       "dependencies": {
         "@types/node": {
@@ -19328,218 +19090,23 @@
       }
     },
     "web3-eth": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.7.3.tgz",
-      "integrity": "sha512-BCIRMPwaMlTCbswXyGT6jj9chCh9RirbDFkPtvqozfQ73HGW7kP78TXXf9+Xdo1GjutQfxi/fQ9yPdxtDJEpDA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.4.tgz",
+      "integrity": "sha512-8OIVMLbvmx+LB5RZ4tDhXuFGWSdNMrCZ4HM0+PywQ08uEcmAcqTMFAn4vdPii+J8gCatZR501r1KdzX3SDLoPw==",
       "requires": {
-        "web3-core": "1.7.3",
-        "web3-core-helpers": "1.7.3",
-        "web3-core-method": "1.7.3",
-        "web3-core-subscriptions": "1.7.3",
-        "web3-eth-abi": "1.7.3",
-        "web3-eth-accounts": "1.7.3",
-        "web3-eth-contract": "1.7.3",
-        "web3-eth-ens": "1.7.3",
-        "web3-eth-iban": "1.7.3",
-        "web3-eth-personal": "1.7.3",
-        "web3-net": "1.7.3",
-        "web3-utils": "1.7.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          },
-          "dependencies": {
-            "@types/bn.js": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "bn.js": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-            }
-          }
-        },
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        },
-        "web3-core": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
-          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "@types/node": "^12.12.6",
-            "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-requestmanager": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
-          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
-          "requires": {
-            "web3-eth-iban": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
-          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
-          "requires": {
-            "@ethersproject/transactions": "^5.0.0-beta.135",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
-          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
-          "requires": {
-            "eventemitter3": "4.0.4"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
-          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
-          "requires": {
-            "util": "^0.12.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-providers-http": "1.7.3",
-            "web3-providers-ipc": "1.7.3",
-            "web3-providers-ws": "1.7.3"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
-          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.3.tgz",
-          "integrity": "sha512-ZlD8DrJro0ocnbZViZpAoMX44x5aYAb73u2tMq557rMmpiluZNnhcCYF/NnVMy6UIkn7SF/qEA45GXA1ne6Tnw==",
-          "requires": {
-            "@ethersproject/abi": "5.0.7",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.3.tgz",
-          "integrity": "sha512-7mjkLxCNMWlQrlfM/MmNnlKRHwFk5XrZcbndoMt3KejcqDP6dPHi2PZLutEcw07n/Sk8OMpSamyF3QiGfmyRxw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "web3-core": "1.7.3",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-eth-abi": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
-          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
-          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
-          "requires": {
-            "web3-core-helpers": "1.7.3",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
-          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
-          "requires": {
-            "oboe": "2.1.5",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
-          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3",
-            "websocket": "^1.0.32"
-          }
-        },
-        "web3-utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
-          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethereumjs-util": "^7.1.0",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "utf8": "3.0.0"
-          }
-        }
+        "underscore": "1.9.1",
+        "web3-core": "1.3.4",
+        "web3-core-helpers": "1.3.4",
+        "web3-core-method": "1.3.4",
+        "web3-core-subscriptions": "1.3.4",
+        "web3-eth-abi": "1.3.4",
+        "web3-eth-accounts": "1.3.4",
+        "web3-eth-contract": "1.3.4",
+        "web3-eth-ens": "1.3.4",
+        "web3-eth-iban": "1.3.4",
+        "web3-eth-personal": "1.3.4",
+        "web3-net": "1.3.4",
+        "web3-utils": "1.3.4"
       }
     },
     "web3-eth-abi": {
@@ -19553,31 +19120,23 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.7.3.tgz",
-      "integrity": "sha512-aDaWjW1oJeh0LeSGRVyEBiTe/UD2/cMY4dD6pQYa8dOhwgMtNQjxIQ7kacBBXe7ZKhjbIFZDhvXN4mjXZ82R2Q==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.4.tgz",
+      "integrity": "sha512-gz9ReSmQEjqbYAjpmAx+UZF4CVMbyS4pfjSYWGAnNNI+Xz0f0u0kCIYXQ1UEaE+YeLcYiE+ZlZdgg6YoatO5nA==",
       "requires": {
-        "@ethereumjs/common": "^2.5.0",
-        "@ethereumjs/tx": "^3.3.2",
         "crypto-browserify": "3.12.0",
         "eth-lib": "0.2.8",
-        "ethereumjs-util": "^7.0.10",
+        "ethereumjs-common": "^1.3.2",
+        "ethereumjs-tx": "^2.1.1",
         "scrypt-js": "^3.0.1",
+        "underscore": "1.9.1",
         "uuid": "3.3.2",
-        "web3-core": "1.7.3",
-        "web3-core-helpers": "1.7.3",
-        "web3-core-method": "1.7.3",
-        "web3-utils": "1.7.3"
+        "web3-core": "1.3.4",
+        "web3-core-helpers": "1.3.4",
+        "web3-core-method": "1.3.4",
+        "web3-utils": "1.3.4"
       },
       "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-          "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -19593,177 +19152,33 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
           "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-            }
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
           }
         },
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
           "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
           }
         },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        },
-        "web3-core": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
-          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "@types/node": "^12.12.6",
-            "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-requestmanager": "1.7.3",
-            "web3-utils": "1.7.3"
-          },
-          "dependencies": {
-            "@types/bn.js": {
-              "version": "4.11.6",
-              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-              "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "@types/node": {
-              "version": "12.20.52",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-              "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
-            }
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
-          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
-          "requires": {
-            "web3-eth-iban": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
-          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
-          "requires": {
-            "@ethersproject/transactions": "^5.0.0-beta.135",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
-          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
-          "requires": {
-            "eventemitter3": "4.0.4"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
-          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
-          "requires": {
-            "util": "^0.12.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-providers-http": "1.7.3",
-            "web3-providers-ipc": "1.7.3",
-            "web3-providers-ws": "1.7.3"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
-          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
-          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
-          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
-          "requires": {
-            "web3-core-helpers": "1.7.3",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
-          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
-          "requires": {
-            "oboe": "2.1.5",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
-          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3",
-            "websocket": "^1.0.32"
-          }
-        },
-        "web3-utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
-          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethereumjs-util": "^7.1.0",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "utf8": "3.0.0"
-          }
         }
       }
     },
@@ -19784,214 +19199,19 @@
       }
     },
     "web3-eth-ens": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.7.3.tgz",
-      "integrity": "sha512-q7+hFGHIc0mBI3LwgRVcLCQmp6GItsWgUtEZ5bjwdjOnJdbjYddm7PO9RDcTDQ6LIr7hqYaY4WTRnDHZ6BEt5Q==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.4.tgz",
+      "integrity": "sha512-b0580tQyQwpV2wyacwQiBEfQmjCUln5iPhge3IBIMXaI43BUNtH3lsCL9ERFQeOdweB4o+6rYyNYr6xbRcSytg==",
       "requires": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
-        "web3-core": "1.7.3",
-        "web3-core-helpers": "1.7.3",
-        "web3-core-promievent": "1.7.3",
-        "web3-eth-abi": "1.7.3",
-        "web3-eth-contract": "1.7.3",
-        "web3-utils": "1.7.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          },
-          "dependencies": {
-            "@types/bn.js": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "bn.js": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-            }
-          }
-        },
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        },
-        "web3-core": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
-          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "@types/node": "^12.12.6",
-            "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-requestmanager": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
-          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
-          "requires": {
-            "web3-eth-iban": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
-          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
-          "requires": {
-            "@ethersproject/transactions": "^5.0.0-beta.135",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
-          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
-          "requires": {
-            "eventemitter3": "4.0.4"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
-          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
-          "requires": {
-            "util": "^0.12.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-providers-http": "1.7.3",
-            "web3-providers-ipc": "1.7.3",
-            "web3-providers-ws": "1.7.3"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
-          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.3.tgz",
-          "integrity": "sha512-ZlD8DrJro0ocnbZViZpAoMX44x5aYAb73u2tMq557rMmpiluZNnhcCYF/NnVMy6UIkn7SF/qEA45GXA1ne6Tnw==",
-          "requires": {
-            "@ethersproject/abi": "5.0.7",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.3.tgz",
-          "integrity": "sha512-7mjkLxCNMWlQrlfM/MmNnlKRHwFk5XrZcbndoMt3KejcqDP6dPHi2PZLutEcw07n/Sk8OMpSamyF3QiGfmyRxw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "web3-core": "1.7.3",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-eth-abi": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
-          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
-          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
-          "requires": {
-            "web3-core-helpers": "1.7.3",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
-          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
-          "requires": {
-            "oboe": "2.1.5",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
-          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3",
-            "websocket": "^1.0.32"
-          }
-        },
-        "web3-utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
-          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethereumjs-util": "^7.1.0",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "utf8": "3.0.0"
-          }
-        }
+        "underscore": "1.9.1",
+        "web3-core": "1.3.4",
+        "web3-core-helpers": "1.3.4",
+        "web3-core-promievent": "1.3.4",
+        "web3-eth-abi": "1.3.4",
+        "web3-eth-contract": "1.3.4",
+        "web3-utils": "1.3.4"
       }
     },
     "web3-eth-iban": {
@@ -20011,370 +19231,33 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.7.3.tgz",
-      "integrity": "sha512-iTLz2OYzEsJj2qGE4iXC1Gw+KZN924fTAl0ESBFs2VmRhvVaM7GFqZz/wx7/XESl3GVxGxlRje3gNK0oGIoYYQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.4.tgz",
+      "integrity": "sha512-JiTbaktYVk1j+S2EDooXAhw5j/VsdvZfKRmHtXUe/HizPM9ETXmj1+ne4RT6m+950jQ7DJwUF3XU1FKYNtEDwQ==",
       "requires": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.7.3",
-        "web3-core-helpers": "1.7.3",
-        "web3-core-method": "1.7.3",
-        "web3-net": "1.7.3",
-        "web3-utils": "1.7.3"
+        "web3-core": "1.3.4",
+        "web3-core-helpers": "1.3.4",
+        "web3-core-method": "1.3.4",
+        "web3-net": "1.3.4",
+        "web3-utils": "1.3.4"
       },
       "dependencies": {
         "@types/node": {
           "version": "12.20.52",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
           "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          },
-          "dependencies": {
-            "@types/bn.js": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "bn.js": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-            }
-          }
-        },
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        },
-        "web3-core": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
-          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "@types/node": "^12.12.6",
-            "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-requestmanager": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
-          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
-          "requires": {
-            "web3-eth-iban": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
-          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
-          "requires": {
-            "@ethersproject/transactions": "^5.0.0-beta.135",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
-          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
-          "requires": {
-            "eventemitter3": "4.0.4"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
-          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
-          "requires": {
-            "util": "^0.12.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-providers-http": "1.7.3",
-            "web3-providers-ipc": "1.7.3",
-            "web3-providers-ws": "1.7.3"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
-          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
-          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
-          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
-          "requires": {
-            "web3-core-helpers": "1.7.3",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
-          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
-          "requires": {
-            "oboe": "2.1.5",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
-          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3",
-            "websocket": "^1.0.32"
-          }
-        },
-        "web3-utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
-          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethereumjs-util": "^7.1.0",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "utf8": "3.0.0"
-          }
         }
       }
     },
     "web3-net": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.7.3.tgz",
-      "integrity": "sha512-zAByK0Qrr71k9XW0Adtn+EOuhS9bt77vhBO6epAeQ2/VKl8rCGLAwrl3GbeEl7kWa8s/su72cjI5OetG7cYR0g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.4.tgz",
+      "integrity": "sha512-wVyqgVC3Zt/0uGnBiR3GpnsS8lvOFTDgWZMxAk9C6Guh8aJD9MUc7pbsw5rHrPUVe6S6RUfFJvh/Xq8oMIQgSw==",
       "requires": {
-        "web3-core": "1.7.3",
-        "web3-core-method": "1.7.3",
-        "web3-utils": "1.7.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          },
-          "dependencies": {
-            "@types/bn.js": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "bn.js": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-            }
-          }
-        },
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        },
-        "web3-core": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
-          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "@types/node": "^12.12.6",
-            "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-requestmanager": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
-          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
-          "requires": {
-            "web3-eth-iban": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
-          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
-          "requires": {
-            "@ethersproject/transactions": "^5.0.0-beta.135",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
-          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
-          "requires": {
-            "eventemitter3": "4.0.4"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
-          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
-          "requires": {
-            "util": "^0.12.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-providers-http": "1.7.3",
-            "web3-providers-ipc": "1.7.3",
-            "web3-providers-ws": "1.7.3"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
-          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
-          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
-          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
-          "requires": {
-            "web3-core-helpers": "1.7.3",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
-          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
-          "requires": {
-            "oboe": "2.1.5",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
-          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3",
-            "websocket": "^1.0.32"
-          }
-        },
-        "web3-utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
-          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethereumjs-util": "^7.1.0",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-core": "1.3.4",
+        "web3-core-method": "1.3.4",
+        "web3-utils": "1.3.4"
       }
     },
     "web3-provider-engine": {
@@ -20459,186 +19342,14 @@
       }
     },
     "web3-shh": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.7.3.tgz",
-      "integrity": "sha512-bQTSKkyG7GkuULdZInJ0osHjnmkHij9tAySibpev1XjYdjLiQnd0J9YGF4HjvxoG3glNROpuCyTaRLrsLwaZuw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.4.tgz",
+      "integrity": "sha512-zoeww5mxLh3xKcqbX85irQbtFe5pc5XwrgjvmdMkhkOdZzPASlWOgqzUFtaPykpLwC3yavVx4jG5RqifweXLUA==",
       "requires": {
-        "web3-core": "1.7.3",
-        "web3-core-method": "1.7.3",
-        "web3-core-subscriptions": "1.7.3",
-        "web3-net": "1.7.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
-        "ethereumjs-util": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
-          "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          },
-          "dependencies": {
-            "@types/bn.js": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-              "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-              "requires": {
-                "@types/node": "*"
-              }
-            },
-            "bn.js": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-              "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-            }
-          }
-        },
-        "eventemitter3": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        },
-        "web3-core": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.3.tgz",
-          "integrity": "sha512-4RNxueGyevD1XSjdHE57vz/YWRHybpcd3wfQS33fgMyHZBVLFDNwhn+4dX4BeofVlK/9/cmPAokLfBUStZMLdw==",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "@types/node": "^12.12.6",
-            "bignumber.js": "^9.0.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-method": "1.7.3",
-            "web3-core-requestmanager": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.3.tgz",
-          "integrity": "sha512-qS2t6UKLhRV/6C7OFHtMeoHphkcA+CKUr2vfpxy4hubs3+Nj28K9pgiqFuvZiXmtEEwIAE2A28GBOC3RdcSuFg==",
-          "requires": {
-            "web3-eth-iban": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.3.tgz",
-          "integrity": "sha512-SeF8YL/NVFbj/ddwLhJeS0io8y7wXaPYA2AVT0h2C2ESYkpvOtQmyw2Bc3aXxBmBErKcbOJjE2ABOKdUmLSmMA==",
-          "requires": {
-            "@ethersproject/transactions": "^5.0.0-beta.135",
-            "web3-core-helpers": "1.7.3",
-            "web3-core-promievent": "1.7.3",
-            "web3-core-subscriptions": "1.7.3",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.3.tgz",
-          "integrity": "sha512-+mcfNJLP8h2JqcL/UdMGdRVfTdm+bsoLzAFtLpazE4u9kU7yJUgMMAqnK59fKD3Zpke3DjaUJKwz1TyiGM5wig==",
-          "requires": {
-            "eventemitter3": "4.0.4"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.3.tgz",
-          "integrity": "sha512-bC+jeOjPbagZi2IuL1J5d44f3zfPcgX+GWYUpE9vicNkPUxFBWRG+olhMo7L+BIcD57cTmukDlnz+1xBULAjFg==",
-          "requires": {
-            "util": "^0.12.0",
-            "web3-core-helpers": "1.7.3",
-            "web3-providers-http": "1.7.3",
-            "web3-providers-ipc": "1.7.3",
-            "web3-providers-ws": "1.7.3"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.3.tgz",
-          "integrity": "sha512-/i1ZCLW3SDxEs5mu7HW8KL4Vq7x4/fDXY+yf/vPoDljlpvcLEOnI8y9r7om+0kYwvuTlM6DUHHafvW0221TyRQ==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.3.tgz",
-          "integrity": "sha512-1GPVWgajwhh7g53mmYDD1YxcftQniIixMiRfOqlnA1w0mFGrTbCoPeVaSQ3XtSf+rYehNJIZAUeDBnONVjXXmg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "web3-utils": "1.7.3"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.3.tgz",
-          "integrity": "sha512-TQJfMsDQ5Uq9zGMYlu7azx1L7EvxW+Llks3MaWn3cazzr5tnrDbGh6V17x6LN4t8tFDHWx0rYKr3mDPqyTjOZw==",
-          "requires": {
-            "web3-core-helpers": "1.7.3",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.3.tgz",
-          "integrity": "sha512-Z4EGdLKzz6I1Bw+VcSyqVN4EJiT2uAro48Am1eRvxUi4vktGoZtge1ixiyfrRIVb6nPe7KnTFl30eQBtMqS0zA==",
-          "requires": {
-            "oboe": "2.1.5",
-            "web3-core-helpers": "1.7.3"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.3.tgz",
-          "integrity": "sha512-PpykGbkkkKtxPgv7U4ny4UhnkqSZDfLgBEvFTXuXLAngbX/qdgfYkhIuz3MiGplfL7Yh93SQw3xDjImXmn2Rgw==",
-          "requires": {
-            "eventemitter3": "4.0.4",
-            "web3-core-helpers": "1.7.3",
-            "websocket": "^1.0.32"
-          }
-        },
-        "web3-utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
-          "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "ethereum-bloom-filters": "^1.0.6",
-            "ethereumjs-util": "^7.1.0",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
-            "utf8": "3.0.0"
-          }
-        }
+        "web3-core": "1.3.4",
+        "web3-core-method": "1.3.4",
+        "web3-core-subscriptions": "1.3.4",
+        "web3-net": "1.3.4"
       }
     },
     "web3-utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "vue-router": "^3.5.1",
     "vue-script2": "^2.1.0",
     "vuex": "^3.6.2",
-    "web3": "^1.7.3",
+    "web3": "^1.3.4",
     "web3-eth-contract": "^1.3.4"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@chenfengyuan/vue-countdown": "^1.1.5",
     "@metamask/onboarding": "^1.0.1",
     "@types/three": "^0.129.0",
+    "@walletconnect/web3-provider": "^1.7.8",
     "@waxio/waxjs": "^0.0.15",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.1",
@@ -41,7 +42,7 @@
     "vue-router": "^3.5.1",
     "vue-script2": "^2.1.0",
     "vuex": "^3.6.2",
-    "web3": "^1.3.4",
+    "web3": "^1.7.3",
     "web3-eth-contract": "^1.3.4"
   },
   "devDependencies": {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -158,6 +158,13 @@ interface StoreMappedActions {
   configureMetaMask: () => void,
 }
 
+interface StoreMappedMutations {
+  setWeb3: (web3: Web3) => void,
+  updateCurrentChainSupportsMerchandise: () => void,
+  updateCurrentChainSupportsPvP: () => void,
+  updateCurrentChainSupportsQuests: () => void,
+}
+
 interface Notification {
   hash: string,
   title: string,
@@ -246,7 +253,12 @@ export default Vue.extend({
       'fetchRewardsClaimTax',
       'configureMetaMask',
     ]) as StoreMappedActions,
-    ...mapMutations(['setWeb3', 'updateCurrentChainSupportsMerchandise', 'updateCurrentChainSupportsPvP', 'updateCurrentChainSupportsQuests']) as StoreMappedMutations,
+    ...mapMutations([
+      'setWeb3',
+      'updateCurrentChainSupportsMerchandise',
+      'updateCurrentChainSupportsPvP',
+      'updateCurrentChainSupportsQuests'
+    ])as StoreMappedMutations,
     async checkChainAndParams(){
       const currentChain = localStorage.getItem('currentChain') || 'BNB';
       const paramChain = this.$router.currentRoute.query.chain;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -261,7 +261,6 @@ export default Vue.extend({
 
       if(!paramChain){
         localStorage.setItem('currentChain', currentChain);
-        console.log('addTo', currentChain);
         addChainToRouter(currentChain);
       }
 
@@ -474,7 +473,6 @@ export default Vue.extend({
     }
   },
   async created() {
-    console.log(localStorage.getItem('walletconnect'));
     this.checkChainAndParams();
     this.checkStorage();
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -220,7 +220,7 @@ export default Vue.extend({
     },
 
     isWalletConnect(): boolean {
-      return localStorage.getItem('walletconnect') === '';
+      return localStorage.getItem('walletconnect') !== null;
     },
 
     isOptions(): boolean {
@@ -474,6 +474,7 @@ export default Vue.extend({
     }
   },
   async created() {
+    console.log(localStorage.getItem('walletconnect'));
     this.checkChainAndParams();
     this.checkStorage();
 

--- a/frontend/src/contracts.ts
+++ b/frontend/src/contracts.ts
@@ -101,18 +101,21 @@ interface Chain {
   chains: Record<string, Record<string, any>>;
 }
 
-export function getConfigValue(key: string): any {
+export function getConfigValue(key: string, chain?: string): any {
   if (process.env.VUE_APP_STAGE === 'alpha') {
     return process.env[key];
   }
 
   if(process.env.NODE_ENV === 'development') return '';
   const env = window.location.href.startsWith('https://test') ? 'test' : 'production';
-  let chain = localStorage.getItem('currentChain') || 'BNB';
-  if(!config.supportedChains.includes(chain)){
-    chain = 'BNB';
+
+  if(chain) return (config as Config).environments[env].chains[chain][key];
+
+  let currentChain = localStorage.getItem('currentChain') || 'BNB';
+  if(!config.supportedChains.includes(currentChain)){
+    currentChain = 'BNB';
   }
-  return (config as Config).environments[env].chains[chain][key];
+  return (config as Config).environments[env].chains[currentChain][key];
 }
 
 let networkId = getConfigValue('VUE_APP_NETWORK_ID') || '5777';

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1375,7 +1375,7 @@
   "app": {
     "cantView": "You can't currently view the app right now. You can try clearing LocalStorage to reset your settings.",
     "warning": {
-      "title": "Metamask Not Detected Or Incorrect Network",
+      "title": "Metamask Not Detected",
       "start": "Get Started With CryptoBlades",
       "buttons": {
         "addMetamask": "Add MetaMask",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,8 +9,6 @@ import Vuex from 'vuex';
 import VueRouter from 'vue-router';
 import VTooltip from 'v-tooltip';
 
-import Web3 from 'web3';
-
 import { createStore } from './store/store';
 import createRouter from './router';
 
@@ -30,8 +28,6 @@ if(getConfigValue('VUE_APP_EXPECTED_NETWORK_ID')) {
 }
 const expectedNetworkName = getConfigValue('VUE_APP_EXPECTED_NETWORK_NAME');
 
-const web3 = new Web3(Web3.givenProvider || process.env.VUE_APP_WEB3_FALLBACK_PROVIDER);
-
 Vue.config.productionTip = false;
 
 Vue.use(Vuex);
@@ -44,14 +40,13 @@ Vue.use(BootstrapVueIcons);
 
 Vue.use(require('vue-script2'));
 
-const store = createStore(web3);
+const store = createStore();
 export const router = createRouter();
 
 new Vue({
   render: h => h(App),
   router, store, i18n,
   provide: {
-    web3,
     // maybe feature flags should just reference the feature-flags.ts module directly?
     featureFlagRaid, featureFlagReforging,
     expectedNetworkId, expectedNetworkName

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -1031,7 +1031,7 @@ export function createStore() {
     },
 
     actions: {
-      async initialize({ dispatch }) {
+      async initializeStore({ dispatch }) {
         await dispatch('setUpContracts');
         await dispatch('setUpContractEvents');
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -2553,7 +2553,7 @@ export function createStore() {
           getGasPrice(),
           defaultCallOptions(state),
           defaultCallOptions(state),
-          new BigNumber(web3.utils.toWei('100', 'ether')),
+          new BigNumber(state.web3.utils.toWei('100', 'ether')),
           state.skillRewards
         );
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -1061,10 +1061,8 @@ export function createStore() {
           commit('setNetworkId', networkId);
           refreshUserDetails = true;
         }
-        console.log('requestAccounts; net id: ',await state.web3.eth.net.getId());
-        console.log(state.web3);
+
         const accounts = await state.web3.eth.getAccounts();
-        console.log(accounts);
 
         if (!_.isEqual(state.accounts, accounts)) {
           commit('setAccounts', { accounts });
@@ -1266,7 +1264,6 @@ export function createStore() {
       },
 
       async setUpContracts({state, commit }) {
-        console.log('1269', state.web3);
         const contracts = await setUpContracts(state.web3);
         commit('setContracts', () => contracts);
       },
@@ -2938,7 +2935,6 @@ export function createStore() {
 
       async fetchTotalRenameTags({ state }) {
         const { CharacterRenameTagConsumables } = state.contracts();
-        //console.log(CharacterRenameTagConsumables+' / '+!state.defaultAccount);
         if(!CharacterRenameTagConsumables || !state.defaultAccount) return;
         return await CharacterRenameTagConsumables.methods.getItemCount().call(defaultCallOptions(state));
       },

--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -12,8 +12,6 @@ import {abi as erc20Abi} from '../../../build/contracts/ERC20.json';
 BigNumber.config({ROUNDING_MODE: BigNumber.ROUND_DOWN});
 BigNumber.config({EXPONENTIAL_AT: 100});
 
-const web3 = new Web3(Web3.givenProvider || process.env.VUE_APP_WEB3_FALLBACK_PROVIDER);
-
 export function addChainToRouter(chain: string) {
   router.replace(
     {
@@ -91,9 +89,9 @@ export const copyNftUrl = (id: number | string, type?: string): void => {
 
 export const addTokenToMetamask = async (address: string, symbol: string): Promise<void> => {
   try {
-    const contract = new web3.eth.Contract(erc20Abi as any[], address);
+    const contract = new (window as any).ethereum.Contract(erc20Abi as any[], address);
     const decimals = await contract.methods.decimals().call();
-    await (web3.currentProvider as any).request({
+    await (window as any).ethereum?.request({
       method: 'wallet_watchAsset',
       params: {
         type: 'ERC20',

--- a/frontend/src/views/Options.vue
+++ b/frontend/src/views/Options.vue
@@ -150,6 +150,10 @@ interface StoreMappedGetters {
   getWeb3: any;
 }
 
+interface RPCS {
+  [key: number]: string;
+}
+
 enum ClaimStage {
   WaxBridge = 0,
   Stake = 1,
@@ -344,16 +348,15 @@ export default Vue.extend({
 
         console.log('connecting to net ',+getConfigValue('VUE_APP_NETWORK_ID'));
 
+        const rpcs = {} as RPCS;
+        config.supportedChains.forEach((chain) => {
+          const chainId = getConfigValue('VUE_APP_NETWORK_ID', chain);
+          rpcs[chainId] = getConfigValue('rpcUrls',chain)[0];
+        });
+
         //  Create WalletConnect Provider
         const provider = new WalletConnectProvider({
-          rpc: {
-            56: 'https://bsc-dataseed.binance.org/',
-            128: 'https://http-mainnet.hecochain.com',
-            66: 'https://exchainrpc.okex.org',
-            137: 'https://matic-mainnet.chainstacklabs.com',
-            43114: 'https://api.avax.network/ext/bc/C/rpc',
-            1313161554: 'https://mainnet.aurora.dev'
-          },
+          rpc: rpcs,
           chainId: +getConfigValue('VUE_APP_NETWORK_ID'),
         });
 

--- a/frontend/src/views/Options.vue
+++ b/frontend/src/views/Options.vue
@@ -162,9 +162,7 @@ enum ClaimStage {
 
 export default Vue.extend({
   async created() {
-    console.log(getConfigValue('currencyNetwork'));
     if(this.isWalletConnect) this.walletConnectChain = getConfigValue('currencyNetwork');
-    console.log('isWalletConnect', this.isWalletConnect);
     this.showGraphics = localStorage.getItem('useGraphics') === 'true';
     this.hideRewards = localStorage.getItem('hideRewards') === 'true';
     this.hideAdvanced = localStorage.getItem('hideAdvanced') === 'true';
@@ -327,7 +325,6 @@ export default Vue.extend({
     },
 
     async setCurrentChain() {
-      console.log(+getConfigValue('VUE_APP_NETWORK_ID'));
       localStorage.setItem('currentChain', this.currentChain);
       this.updateCurrentChainSupportsMerchandise();
       this.updateCurrentChainSupportsPvP();
@@ -345,8 +342,6 @@ export default Vue.extend({
         this.connectingWalletConnect = true;
         this.currentChain = this.walletConnectChain;
         this.setCurrentChain();
-
-        console.log('connecting to net ',+getConfigValue('VUE_APP_NETWORK_ID'));
 
         const rpcs = {} as RPCS;
         config.supportedChains.forEach((chain) => {


### PR DESCRIPTION
- store was previously created in main.ts with web3 as a parameter `const store = createStore(web3);`
- web3 was defined as `const web3 = new Web3(Web3.givenProvider);`
- If we add `web3` to our vuex store.state + setter/getter, we can use Web3.givenProvider or use walletConnectProvider or any other provider. This also allows us later to add more wallets easily
- the whole app uses now the same web3 object from vuex. common.ts is just using the injected window.ethereum


Onboarding / Warnings - Flow changed a bit:
1. No provider detected and wallet connect not set in localStorage
--> open the 'No MM detected' - Warning with 'Add MetaMask' & 'WalletConnect' button (we can put more wallets here later)
1.1 'Add MM' --> as usual
1.2 'WalletConnect' --> router.push to Options and supress the dialogs
2. MM connected, but not properly configured
--> 'MM successfully connected' - Modal is shown with the 'configure MM' btn now disabled, if everything went well (test request went trough)
3. Wallet Connect is set (wallet connect sets a localStorage entry if it was connected), ignore provider + don't config them, hide MM warning, hide Network warning + init connection

The wallet connect chain can be switched by disconnecting the previous connection in Options.

- converted `App.vue` to ts
- cleanup 


To test:
Download any walletconnect-compatible wallet. E.g. Wallet 3, Trustwallet, etc. ..  (https://docs.binance.org/guides/concepts/walletconnect.html)