### PR TITLE
Fix Heco requiring 0.113H to load characters

### DIFF
--- a/frontend/src/store/pvp/index.ts
+++ b/frontend/src/store/pvp/index.ts
@@ -12,7 +12,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const fighter = await PvpCore.methods.fighterByCharacter(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const fighter = await PvpCore.methods.fighterByCharacter(characterId).call({ from: rootState.defaultAccount });
 
       return fighter;
     },
@@ -21,7 +21,7 @@ const pvp = {
       const { PvpRankings } = rootState.contracts();
       if (!PvpRankings || !rootState.defaultAccount) return;
 
-      const currentRankedSeason = await PvpRankings.methods.currentRankedSeason().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const currentRankedSeason = await PvpRankings.methods.currentRankedSeason().call({ from: rootState.defaultAccount });
 
       return currentRankedSeason;
     },
@@ -30,7 +30,7 @@ const pvp = {
       const { PvpRankings } = rootState.contracts();
       if (!PvpRankings || !rootState.defaultAccount) return;
 
-      const seasonStartedAt = await PvpRankings.methods.seasonStartedAt().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const seasonStartedAt = await PvpRankings.methods.seasonStartedAt().call({ from: rootState.defaultAccount });
 
       return seasonStartedAt;
     },
@@ -39,7 +39,7 @@ const pvp = {
       const { PvpRankings } = rootState.contracts();
       if (!PvpRankings || !rootState.defaultAccount) return;
 
-      const seasonDuration = await PvpRankings.methods.seasonDuration().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const seasonDuration = await PvpRankings.methods.seasonDuration().call({ from: rootState.defaultAccount });
 
       return seasonDuration;
     },
@@ -48,7 +48,7 @@ const pvp = {
       const { Characters } = rootState.contracts();
       if (!Characters || !rootState.defaultAccount) return;
 
-      const characterLevel = await Characters.methods.getLevel(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const characterLevel = await Characters.methods.getLevel(characterId).call({ from: rootState.defaultAccount });
 
       return characterLevel;
     },
@@ -57,7 +57,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const characterFullPower = await PvpCore.methods.getCharacterPower(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const characterFullPower = await PvpCore.methods.getCharacterPower(characterId).call({ from: rootState.defaultAccount });
 
       return characterFullPower;
     },
@@ -78,7 +78,7 @@ const pvp = {
       const { PvpRankings } = rootState.contracts();
       if (!PvpRankings || !rootState.defaultAccount) return;
 
-      const rankingsPoolByTier = await PvpRankings.methods.rankingsPoolByTier(tier).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const rankingsPoolByTier = await PvpRankings.methods.rankingsPoolByTier(tier).call({ from: rootState.defaultAccount });
 
       return rankingsPoolByTier;
     },
@@ -87,7 +87,7 @@ const pvp = {
       const { PvpRankings } = rootState.contracts();
       if (!PvpRankings || !rootState.defaultAccount) return;
 
-      const tierTopCharacters = await PvpRankings.methods.getTierTopCharacters(tier).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const tierTopCharacters = await PvpRankings.methods.getTierTopCharacters(tier).call({ from: rootState.defaultAccount });
 
       return tierTopCharacters;
     },
@@ -96,7 +96,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const arenaTier = await PvpCore.methods.getArenaTier(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const arenaTier = await PvpCore.methods.getArenaTier(characterId).call({ from: rootState.defaultAccount });
 
       return arenaTier;
     },
@@ -105,7 +105,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const arenaTier = await PvpCore.methods.previousTierByCharacter(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const arenaTier = await PvpCore.methods.previousTierByCharacter(characterId).call({ from: rootState.defaultAccount });
 
       return arenaTier;
     },
@@ -114,7 +114,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const entryWager = await PvpCore.methods.getEntryWagerByTier(tier).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const entryWager = await PvpCore.methods.getEntryWagerByTier(tier).call({ from: rootState.defaultAccount });
 
       return entryWager;
     },
@@ -123,7 +123,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const isWeaponInArena = await PvpCore.methods.isWeaponInArena(weaponId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const isWeaponInArena = await PvpCore.methods.isWeaponInArena(weaponId).call({ from: rootState.defaultAccount });
 
       return isWeaponInArena;
     },
@@ -132,7 +132,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const isShieldInArena = await PvpCore.methods.isShieldInArena(shieldId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const isShieldInArena = await PvpCore.methods.isShieldInArena(shieldId).call({ from: rootState.defaultAccount });
 
       return isShieldInArena;
     },
@@ -140,7 +140,7 @@ const pvp = {
     async getIsCharacterInArena({ rootState, commit }: {rootState: IState, commit: Commit}, characterId: number) {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
-      const isCharacterInArena = await PvpCore.methods.isCharacterInArena(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const isCharacterInArena = await PvpCore.methods.isCharacterInArena(characterId).call({ from: rootState.defaultAccount });
       commit('updateCharacterInArena', { characterId, isCharacterInArena });
 
       return isCharacterInArena;
@@ -174,7 +174,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const matchByFinder = await PvpCore.methods.matchByFinder(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const matchByFinder = await PvpCore.methods.matchByFinder(characterId).call({ from: rootState.defaultAccount });
 
       return matchByFinder;
     },
@@ -183,7 +183,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const matchByFinder = await PvpCore.methods.getDuelQueue().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const matchByFinder = await PvpCore.methods.getDuelQueue().call({ from: rootState.defaultAccount });
 
       return matchByFinder;
     },
@@ -192,7 +192,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const matchByFinder = await PvpCore.methods.getDuelCost(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const matchByFinder = await PvpCore.methods.getDuelCost(characterId).call({ from: rootState.defaultAccount });
 
       return matchByFinder;
     },
@@ -201,7 +201,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const matchablePlayerCount = await PvpCore.methods.getMatchablePlayerCount(characterId).call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const matchablePlayerCount = await PvpCore.methods.getMatchablePlayerCount(characterId).call({ from: rootState.defaultAccount });
 
       return matchablePlayerCount;
     },
@@ -210,7 +210,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const decisionSeconds = await PvpCore.methods.decisionSeconds().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const decisionSeconds = await PvpCore.methods.decisionSeconds().call({ from: rootState.defaultAccount});
 
       return decisionSeconds;
     },
@@ -219,7 +219,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const reRollFeePercent = await PvpCore.methods.reRollFeePercent().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const reRollFeePercent = await PvpCore.methods.reRollFeePercent().call({ from: rootState.defaultAccount });
 
       return reRollFeePercent;
     },
@@ -228,7 +228,7 @@ const pvp = {
       const { PvpRankings } = rootState.contracts();
       if (!PvpRankings || !rootState.defaultAccount) return;
 
-      const playerPrizePoolRewards = await PvpRankings.methods.getPlayerPrizePoolRewards().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const playerPrizePoolRewards = await PvpRankings.methods.getPlayerPrizePoolRewards().call({ from: rootState.defaultAccount });
 
       return playerPrizePoolRewards;
     },
@@ -237,7 +237,7 @@ const pvp = {
       const { PvpArena } = rootState.contracts();
       if (!PvpArena || !rootState.defaultAccount) return;
 
-      const playerPrizePoolRewards = await PvpArena.methods.getPlayerPrizePoolRewards().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const playerPrizePoolRewards = await PvpArena.methods.getPlayerPrizePoolRewards().call({ from: rootState.defaultAccount });
 
       return playerPrizePoolRewards;
     },
@@ -246,7 +246,7 @@ const pvp = {
       const { PvpCore } = rootState.contracts();
       if (!PvpCore || !rootState.defaultAccount) return;
 
-      const duelOffsetCost = await PvpCore.methods.duelOffsetCost().call({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
+      const duelOffsetCost = await PvpCore.methods.duelOffsetCost().call({ from: rootState.defaultAccount });
 
       return duelOffsetCost;
     },
@@ -286,7 +286,7 @@ const pvp = {
         return;
       }
 
-      const res = await PvpArena.methods.withdrawFromArena(characterId).send({ from: rootState.defaultAccount });
+      const res = await PvpArena.methods.withdrawFromArena(characterId).send({ from: rootState.defaultAccount, gasPrice: getGasPrice() });
 
       return res;
     },


### PR DESCRIPTION
Added gasPrice to some calls that didn't want it. Resulting in HECO not being able to succeed the call unless over 0.113H in wallet this resolves it.