### PR TITLE
correctly display muted rank loss on front end

### DIFF
--- a/frontend/src/components/smart/PvPArenaMatchMaking.vue
+++ b/frontend/src/components/smart/PvPArenaMatchMaking.vue
@@ -162,7 +162,7 @@
       :defenderPower="duelResult.defenderPower"
       :defenderRoll="duelResult.defenderRoll"
       :skillEarned="duelResult.skillDifference"
-      :rankVariation="duelResult.result === 'win' ? `+${this.duelResult.bonusRank ? 5 + +this.duelResult.bonusRank : 5}` : '-3'"
+      :rankVariation="duelResult.result === 'win' ? `+${this.duelResult.bonusRank ? 5 + +this.duelResult.bonusRank : 5}` : '0'"
       :userCurrentRank="duelResult.rankDifference"
       @close-modal="handleCloseModal"
     />
@@ -525,9 +525,11 @@ export default {
           // TODO: Make this prettier
           this.duelResult.rankDifference = formattedResult.attackerWon ?
             +this.characterInformation.rank + 5 + +this.duelResult.bonusRank :
-            +this.characterInformation.rank - 3 <= 0 ?
-              0 :
-              +this.characterInformation.rank - 3;
+            // Mute ranking loss
+            // +this.characterInformation.rank - 3 <= 0 ?
+            //   0 :
+            //   +this.characterInformation.rank - 3;
+            +this.characterInformation.rank;
 
           subscription.unsubscribe((error, result) => {
             if (!error) {


### PR DESCRIPTION
This PR:
- Correctly shows no rank loss on front end after rank loss mute on contracts.

* Code is hard coded due to setting "losing points" to 0 actually wastes more gas, will optimize for future use.