### PR TITLE
fix ffa arena displaying tiered power after duels

### DIFF
--- a/frontend/src/components/smart/PvPArenaMatchMaking.vue
+++ b/frontend/src/components/smart/PvPArenaMatchMaking.vue
@@ -5,7 +5,12 @@
         {{$t('pvp.arena')}}
       </div>
       <div class="navStats">
-        <div>
+        <div v-if="isUntiered">
+          <span>
+            {{$t('pvp.untiered')}}
+          </span>
+        </div>
+        <div v-else>
           <span>
             {{$t('pvp.arenaTier')}}
           </span>
@@ -683,10 +688,6 @@ export default {
   watch: {
     async match(value) {
       this.loading = true;
-
-      if (value !== null) {
-        this.isUntiered = this.getPreviousTierByCharacter(value) === '20';
-      }
 
       if (value.defenderID) {
         this.$emit('updateOpponentInformation', value.defenderID);


### PR DESCRIPTION
This PR:

- Fixes the front end displaying tiered win chance and power instead of free for all one when it shouldn't