### PR TITLE
Launchpad upgrade

### DIFF
--- a/contracts/Launchpad.sol
+++ b/contracts/Launchpad.sol
@@ -418,12 +418,12 @@ contract Launchpad is Initializable, AccessControlUpgradeable {
     function setTotalUnclaimedCommitted(uint256 launchId, address[] calldata users, uint256[] calldata totalCommittedValues) external onlyPhase1(launchId) launchNotStarted(launchId) restricted {
         require(nextLaunchId >= launchId, "Wrong ID");
         require(users.length > 0 && users.length == totalCommittedValues.length, "Bad input");
-        launchTotalUnclaimedSkillCommittedValue[launchId] = 0;
+        uint256 unclaimedCommittedValue = 0;
         for(uint i = 0; i < users.length; i++) {
             launchUserTotalUnclaimedSkillCommittedValue[launchId][users[i]] = totalCommittedValues[i];
-            launchTotalUnclaimedSkillCommittedValue[launchId] += totalCommittedValues[i];
+            unclaimedCommittedValue += totalCommittedValues[i];
         }
-        launchBaseAllocation[launchId] = launchBaseAllocation[launchId].sub(launchBaseAllocation[launchId].mul(launchTotalUnclaimedSkillCommittedValue[launchId]).div(launchFundsToRaise[launchId]));
+        launchBaseAllocation[launchId] = launchBaseAllocation[launchId].sub(launchBaseAllocation[launchId].mul(unclaimedCommittedValue).div(launchFundsToRaise[launchId]));
     }
 
     // WITHDRAW RAISED FUNDS

--- a/contracts/Launchpad.sol
+++ b/contracts/Launchpad.sol
@@ -58,6 +58,7 @@ contract Launchpad is Initializable, AccessControlUpgradeable {
     mapping(uint256 => mapping(address => uint256)) public launchUserInvestment;
     mapping(uint256 => mapping(address => uint256)) public launchUserUnclaimedSkillCommittedValue;
     mapping(uint256 => uint256) public launchTotalUnclaimedSkillCommittedValue;
+    mapping(uint256 => mapping(address => uint256)) public launchUserTotalUnclaimedSkillCommittedValue;
 
     // VESTING INFO
     mapping(uint256 => uint256[]) launchPeriodicVestingsPercentages;
@@ -67,15 +68,10 @@ contract Launchpad is Initializable, AccessControlUpgradeable {
     mapping(address => mapping(uint256 => uint256)) public userLinearVestingClaimTimestamp;
     mapping(address => mapping(uint256 => mapping(uint256 => bool))) public userClaimedVestingPortion;
 
-
     uint256 public nextLaunchId;
     uint256 public skillPrice;
 
     CryptoBlades _game;
-
-    // USER INFO UPGRADE
-    mapping(uint256 => mapping(address => uint256)) public launchUserTotalUnclaimedSkillCommittedValue;
-
 
     function initialize(CryptoBlades game) public initializer {
         __AccessControl_init_unchained();

--- a/contracts/Launchpad.sol
+++ b/contracts/Launchpad.sol
@@ -138,7 +138,7 @@ contract Launchpad is Initializable, AccessControlUpgradeable {
     }
 
     function _launchNotStarted(uint256 launchId) internal view {
-        require(launchStartTime[launchId] > block.timestamp, "Launch started");
+        require(launchStartTime[launchId] == 0 || launchStartTime[launchId] > block.timestamp, "Launch started");
     }
 
     // VIEWS

--- a/migrations/163_launchpad_testnet.js
+++ b/migrations/163_launchpad_testnet.js
@@ -35,7 +35,7 @@ module.exports = async function (deployer, network, accounts) {
       ],
       [1,2,3,4,5,6,7,8]
     );
-    await launchpad.setVars([2,3,4,5],[1800,1800,1,30]);
+    await launchpad.setVars([2,3,4,5,6,7],[1800,1800,1,30,1800,3600]);
     await launchpad.setSkillPrice('4000000000000000000');
   }
 };


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Change to launch flow.
There's a committing time window added, configurable with vars: 6 and 7.
After the window passes we will grab how much was committed to whitelisted wallets on each chain, sum it up per wallet and push the total committed values for whitelisted wallets to the chain the launch takes place on.

So `commitUnclaimedSkill` now allows to pick a specific whitelisted wallet to commit to.
There's new function `setTotalUnclaimedCommitted` that we will push the totals with.
And the Launch structure now has `commitOnly` field that indicates whether it's possible to invest on this chain or only commit.

I'm intending to redeploy the contract on testnets to be able to modify Launch structure and the layout clean.

### Testing

Tested locally.
