### PR TITLE
UI bug fixes 02

### DIFF
--- a/frontend/src/components/NftIcon.vue
+++ b/frontend/src/components/NftIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-bind:class="isDefault ? 'default-icon-wrapper' : 'nft-icon-wrapper'">
     <div v-if="isDefault" class="nft-default-icon">
-      <img class="default-placeholder" v-if="nft.type === 'weapon'" src="../assets/placeholder/sword-placeholder-1.png"
+      <img class="default-placeholder" v-if="nft.type === 'weapon'" src="../assets/placeholder/weapon3.png"
         v-tooltip="$t('nftIcon.weaponTooltip', {stars: stars || '2-5'})"/>
       <div v-if="nft.type === 'weapon'" class="default-info">{{stars || '2-5'}}*</div>
       <img class="default-junk-placeholder" v-if="nft.type === 'junk'" src="../assets/junk/junk3.png"
@@ -304,7 +304,8 @@ export default {
   width: 100%;
   position: relative;
   background: rgba(4, 4, 4, 0.022);
-  border: 2px solid #9e8a57;
+  border: 1px solid #9e8a57;
+  border-radius: 5px;
 }
 
 .default-info {

--- a/frontend/src/components/WeaponInvetory.vue
+++ b/frontend/src/components/WeaponInvetory.vue
@@ -78,12 +78,12 @@
     <!-- raid selected weapon display  (DESKTOP VIEW)-->
     <div v-if="displayType === 'raid'" class="glow-container" ref="el">
       <div class="weapon-flex">
-        <div :class="'weapon-img-desktop frame-'+ (weapon.stars || 0)" style="border-radius:5px">
+        <div :class="'weapon-img-desktop selected frame-'+ (weapon.stars || 0)" style="border-radius:5px">
             <!-- WEAPON ID -->
           <div class="id">{{$t('weaponIcon.id')}} {{ weapon.id }}</div>
           <img v-if="showPlaceholder" class="placeholder" :src="getWeaponArt(weapon)"  />
         </div>
-        <div class="weapon-details">
+        <div class="weapon-details selected">
 
             <!-- FAVORITE -->
             <b-icon v-if="favorite" class="favorite-star" icon="star-fill" variant="warning" />
@@ -476,6 +476,28 @@ export default {
   text-transform: capitalize !important;
   font-weight: 500;
   font-family: Trajan;
+}
+
+.weapon-img-desktop.selected{
+  max-height: 70px;
+  min-height: 70px;
+  min-width: 70px;
+  max-width: 70px;
+}
+
+.weapon-img-desktop.selected > img{
+  max-height: 65px;
+  min-height: 65px;
+  min-width: 65px;
+  max-width: 65px;
+}
+
+.weapon-img-desktop.selected > div.id{
+  top: 20px;
+}
+
+.weapon-details.selected > .name-desktop{
+  color: #fff;
 }
 
 

--- a/frontend/src/components/smart/CharacterDisplay.vue
+++ b/frontend/src/components/smart/CharacterDisplay.vue
@@ -14,7 +14,7 @@
                 <div class="element-frame">
                     <div>
                       <span
-                        :id="`${setIdForElement(filteredCharacter.trait, filteredCharacter.isSelected)}`"
+                        :id="`${setIdForElement(filteredCharacter.trait, filteredCharacter.id === currentCharacterId)}`"
                       />
                       <span v-if="toggled && getIfCharacterIsInRaid(filteredCharacter.id)" class="raid-indicator"></span>
                       <span v-if="toggled && filteredCharacter.pvpStatus === 'IN_ARENA'" class="pvp-indicator"></span>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -540,6 +540,8 @@
     "bossPower": "Boss Power",
     "drops": "Drops",
     "raid": "Raid",
+    "rewardsFromPrevious": "Rewards from Previous Raid",
+    "noAvailableRewards": "No Available Rewards",
     "clickAnywhere": "Click Anywhere to continue",
     "dropChance": "Drop Chance",
     "allRewardRemove": "All rewards will be removed if unclaimed for seven days",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -46,7 +46,7 @@
     "claim": "Claim",
     "characterName": "Character Name",
     "unclaimedExp": "Unclaimed EXP",
-    "unclaimed": "UNLCAIMED SKILL",
+    "unclaimed": "UNCLAIMED SKILL",
     "widthraw": "WITHDRAW",
     "claimRewards": "Claim Rewards",
     "payoutCurrency": "Payout Currency",

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -173,7 +173,9 @@
                       </div>
                   </div>
                   <div class="col-lg-12 join-raid">
-                    <button class="claim-btn" @click="promptRewardClaim()" v-tooltip="'Rewards from Previous Raid'">
+                    <button class="claim-btn" :class="rewardIndexes !== null && rewardIndexes.length > 0 ? 'opacity-1': 'opacity-0'"
+                      @click="promptRewardClaim()" v-tooltip="rewardIndexes !== null && rewardIndexes.length > 0 ?
+                      $t('raid.rewardsFromPrevious'): $t('raid.noAvailableRewards')">
                       {{$t('raid.claimRewards').toUpperCase()}}
                     </button>
                     <button v-if="!isMobile()" class="btn-raid"  v-tooltip="$t('raid.joiningCostStamina', {formatStaminaHours})" @click="joinRaidMethod()">
@@ -1733,6 +1735,16 @@ hr.divider {
   margin-left: 1px;
   font-size: 13px;
    /* margin-top: 10px; */
+}
+
+.opacity-0{
+  opacity: 0.4;
+  cursor:not-allowed;
+}
+
+.opacity-1{
+  opacity: 1;
+  cursor: pointer;
 }
 
 .char-info > div:nth-child(2){

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -178,7 +178,11 @@
                       $t('raid.rewardsFromPrevious'): $t('raid.noAvailableRewards')">
                       {{$t('raid.claimRewards').toUpperCase()}}
                     </button>
-                    <button v-if="!isMobile()" class="btn-raid"  v-tooltip="$t('raid.joiningCostStamina', {formatStaminaHours})" @click="joinRaidMethod()">
+                    <button v-if="!isMobile()" class="btn-raid"
+                    v-tooltip="!isRaidStarted ? $t('raid.errors.raidNotStarted') :
+                    (!this.selectedWeaponId ? $t('raid.errors.selection') : $t('raid.joiningCostStamina', {formatStaminaHours}))"
+                    @click="joinRaidMethod()"
+                    :class="!isRaidStarted || !this.selectedWeaponId ? 'opacity-0': 'opacity-1'">
                       {{$t('raid.joinRaid')}}
                     </button>
                      <button v-else class="btn-raid"  v-tooltip="$t('raid.joiningCostStamina', {formatStaminaHours})" @click="openEquipItems()">

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -100,7 +100,7 @@
                             .
                         </div>
                         <div>
-                          <p class="name bold character-name"> {{getCleanCharacterName(currentCharacterId)}} </p>
+                          <p class="name character-name"> {{getCleanCharacterName(currentCharacterId).toUpperCase()}} </p>
                           <span class="subtext subtext-stats">
                             <p style="text-transform:capitalize"><span :class="traitNumberToName(currentCharacter.trait).toLowerCase()
                             + '-icon trait-icon char-icon'" /> {{ traitNumberToName(currentCharacter.trait).toLowerCase() }} {{$t('raid.element')}}</p>

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -172,8 +172,10 @@
                         <nft-icon :isDefault="true" :nft="{ type: '5bdust' }"/>
                       </div>
                   </div>
+                  <!-- :class="rewardIndexes !== null && rewardIndexes.length > 0 ? 'opacity-1': 'opacity-0'" -->
                   <div class="col-lg-12 join-raid">
-                    <button class="claim-btn" :class="rewardIndexes !== null && rewardIndexes.length > 0 ? 'opacity-1': 'opacity-0'"
+                    <button class="claim-btn"
+                      :disabled="noRewards"
                       @click="promptRewardClaim()" v-tooltip="rewardIndexes !== null && rewardIndexes.length > 0 ?
                       $t('raid.rewardsFromPrevious'): $t('raid.noAvailableRewards')">
                       {{$t('raid.claimRewards').toUpperCase()}}
@@ -526,6 +528,10 @@ export default Vue.extend({
 
     changeEquipedWeapon(){
       Events.$emit('weapon-inventory', true);
+    },
+
+    noRewards(){
+      return this.rewardIndexes === null && this.rewardIndexes.length === 0;
     },
 
     closeRewardPicker(id: any){

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -980,10 +980,6 @@ hr.divider {
   padding-left: 20px;
 }
 
-.weapon-info{
-  margin-top: 10px;
-}
-
 .outline-box > div > p{
   margin: 0px;
   font-size: 15px;


### PR DESCRIPTION

PR Includes: Fixed UI Issues
 - 1.3.3) Old placeholder image for rewarded weapon
 - 1.3.5) The weapon icon should be aligned with the char icon (same size + same font color 
 - 1.3.6) 'Claim Rewards' not visibly disabled when no rewards available
 - 1.5.1) Weird behaviour with the icon color; Last one is still colored when selecting another one
 - 1.3.7) After a user selects a char, a weapon and then clicks 'Join Raid' he get's a pop-up that the raid has not yet started. We should just visibly disable the 'Join Raid' Button beforehand, remove the pop-up and add a tooltip on hover over the disabled btn that says 'Raid has not yet started. Please wait xx:xx:xx'; Same when no weapon is selected