### PR TITLE
more memory

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  chainWebpack: config => {
+    config.plugin('fork-ts-checker').tap(args => {
+      args[0].memoryLimit = 4096;
+      return args;
+    });
+  },
+};


### PR DESCRIPTION
Got this error from the ts worker a lot:
```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```
![image](https://user-images.githubusercontent.com/5601589/172917356-69dd6a04-c7e6-4143-ac31-650061fb0a96.png)

 This change increases the memory limit.