### PR TITLE
Implemented changes for - 1514-raid-timer-truncates-hours

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -109,7 +109,14 @@
               </div>
               <div>
                 <span class="raid-boss-value" v-if="raidData.raidStatus === '0' || raidData.raidStatus === ''">00:00</span>
-                <span class="raid-boss-value" v-else>{{this.remainingTime.minutes}}:{{this.remainingTime.seconds}}</span>
+                <span class="raid-boss-value" v-else>
+                  <span class="raid-boss-value" v-if="this.remainingTime.hours > 0">
+                    {{this.remainingTime.hours}}:{{this.remainingTime.minutes}}:{{this.remainingTime.seconds}}
+                  </span>
+                  <span class="raid-boss-value" v-else>
+                    {{this.remainingTime.minutes}}:{{this.remainingTime.seconds}}
+                  </span>
+                </span>
               </div>
             </div>
           </div>

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -58,11 +58,11 @@
                         </div>
                     </div>
                     <div class="w-limit" v-else>
-                        <div class="day">
+                        <div class="day" v-if="remainingTime.days > 0">
                           <p>{{ zeroPad(remainingTime.days, 2) }}</p>
                           <span>{{ remainingTime.days > 1 ? $t('raid.days') : $t('raid.day') }}</span>
                         </div>
-                        <div class="hour">
+                        <div class="hour" v-if="remainingTime.hours > 0">
                           <p>{{ zeroPad(remainingTime.hours, 2)}}</p>
                           <span>{{ remainingTime.hours > 1 ? $t('raid.hrs') : $t('raid.hr')}}</span>
                         </div>


### PR DESCRIPTION
### All Submissions
Screenshots: 
- raid page view
![1](https://user-images.githubusercontent.com/30393097/177055168-9a9f9538-f85c-426d-b045-ef519051450c.png)


- home page view
![2](https://user-images.githubusercontent.com/30393097/177054639-9c66a18d-d2e5-4d72-a8c0-562b3e5cb217.png)


### New Feature Submissions

This relates to an existing issue - [BUG] - Raid "registration ends" timer truncates hours #1514

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

I have implemented short changes for - [BUG] - Raid "registration ends" timer truncates hours #1514
Changes:
- main page shows hours in raid registration ends timer
- raid page shows days and hours only if their value !== 0

### Testing

The code has been tested locally.
