### PR TITLE
1490 - dust display after salvage

### DIFF
--- a/frontend/src/components/smart/CharacterList.vue
+++ b/frontend/src/components/smart/CharacterList.vue
@@ -345,6 +345,9 @@ export default {
           this.allSelected = false;
           return false;
         }
+        if(this.characterIds.length === this.toBurn.length){
+          this.allSelected = true;
+        }
 
         return true;
       });
@@ -356,6 +359,9 @@ export default {
         if(!idToBurn.includes(filteredCharacter.id)){
           this.allSelected = false;
           return false;
+        }
+        if(this.characterIds.length === this.toBurn.length){
+          this.allSelected = true;
         }
 
         return true;

--- a/frontend/src/raid-boss-art-placeholder.ts
+++ b/frontend/src/raid-boss-art-placeholder.ts
@@ -5,7 +5,7 @@ import hellborn4 from './assets/raid-bosses/CB_Hellborn Overlord.gif';
 import hellborn5 from './assets/raid-bosses/CB_Hellborn Shaman.gif';
 import hellborn6 from './assets/DragonFlyIdle_512.gif';
 
-import customMonster1 from './assets/custom/monster1.png';
+import customMonster1 from './assets/raid-bosses/custom/monster1.png';
 
 // import halloween1 from './assets/raid-bosses/halloween/CB_Hellborn M13.gif';
 // import halloween2 from './assets/raid-bosses/halloween/CB_Hellborn Ste1n.gif';

--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -613,6 +613,7 @@ import Events from '../events';
 import SpecialWeaponForgeModal from '@/components/smart/SpecialWeaponForgeModal.vue';
 import BlacksmithNav from '@/components/BlacksmithNav.vue';
 import { getConfigValue } from '@/contracts';
+import { filter } from 'vue/types/umd';
 
 type StoreMappedState = Pick<IState, 'defaultAccount' | 'ownedWeaponIds' | 'skillBalance' | 'inGameOnlyFunds' | 'skillRewards' >;
 
@@ -1151,6 +1152,7 @@ export default Vue.extend({
         await this.massBurnWeapons({
           burnWeaponIds: this.burnWeaponIds,
         });
+        this.hideWeapons = this.hideWeapons.filter(id => !this.burnWeaponIds.includes(id));
         this.burnWeaponIds = [];
         this.burnWeaponId = null;
         (this.$refs['mass-dust-confirmation-modal'] as BModal).hide();
@@ -1164,7 +1166,6 @@ export default Vue.extend({
         this.cooling = false;
       }
     },
-
     async updateMintWeaponFee() {
       if(!this.contracts.CryptoBlades) return;
       const forgeCost = await this.fetchMintWeaponFee();

--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -613,7 +613,6 @@ import Events from '../events';
 import SpecialWeaponForgeModal from '@/components/smart/SpecialWeaponForgeModal.vue';
 import BlacksmithNav from '@/components/BlacksmithNav.vue';
 import { getConfigValue } from '@/contracts';
-import { filter } from 'vue/types/umd';
 
 type StoreMappedState = Pick<IState, 'defaultAccount' | 'ownedWeaponIds' | 'skillBalance' | 'inGameOnlyFunds' | 'skillRewards' >;
 
@@ -1053,10 +1052,6 @@ export default Vue.extend({
       this.lesserDust = '0';
       this.greaterDust = '0';
       this.powerfulDust = '0';
-    },
-    clearAllMassBurn(){
-      return this.burnWeaponIds = [],
-      this.hideWeapons = this.ownedWeaponIds;
     },
     getWeaponToUpgrade() {
       if(this.reforgeWeaponId){


### PR DESCRIPTION
### All Submissions

![image](https://user-images.githubusercontent.com/30393097/179054701-3d1b17ed-4a39-4910-a491-6ca4173fcab5.png)

### New Feature Submissions

This relates to - The dust display on the right is not reset after salvage #1490

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

I have implemented changes for - 2.5.5) The dust display on the right is not reset after salvage #1490 
https://github.com/CryptoBlades/cryptoblades/issues/1490

Changes:
 - deleted not used method
 - updating list of weapons to show right away
 - locally, no issue with dust list occurred

- [ ]  **Please merge after - https://github.com/CryptoBlades/cryptoblades/pull/1530**

### Testing

Tested locally. On test, Metamask is not letting me salvage weapons.
