### PR TITLE
Add exclamation mark to indicate that rewards are depleted

### DIFF
--- a/frontend/src/components/StakeSelectorItem.vue
+++ b/frontend/src/components/StakeSelectorItem.vue
@@ -2,10 +2,11 @@
   <skeleton-loader v-if="isLoading"/>
   <div v-else class="container">
     <h1 class="stake-type-title">{{ stakeTitle }}
-      <b-icon-question-circle-fill v-if="deprecated"
+      <b-icon-question-circle-fill v-if="deprecated" class="quesition-mark"
         v-tooltip="$t('stake.StakeSelectorItem.deprecatedTooltip')" />
+      <b-icon-exclamation-circle-fill v-if="rewardsDepleted" class="exclamation-mark"
+        v-tooltip="$t('stake.StakeSelectorItem.rewardsDepletedTooltip')" />
     </h1>
-
     <div class="stake-stats">
       <div class="stake-stats-item">
         <div class="stake-stats-item-title">{{ $t('stake.StakeSelectorItem.earn') }}</div>
@@ -374,6 +375,10 @@ export default Vue.extend({
 
     estimatedUnlockTimeLeftFormatted(): string {
       return secondsToDDHHMMSS(this.stakeUnlockTimeLeftCurrentEstimate);
+    },
+
+    rewardsDepleted(): boolean {
+      return this.stakeRewardDistributionTimeLeftCurrentEstimate === 0 && !this.stakedBalance.isZero();
     },
 
     stakedBalance(): BN{
@@ -911,6 +916,15 @@ export default Vue.extend({
   justify-content: center;
   align-items: center;
   height:100%;
+}
+
+.quesition-mark {
+  margin-right:5px;
+}
+
+.exclamation-mark {
+  background-color: red;
+  border-radius: 50%;
 }
 
 /* Mobile */


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?

![Screenshot from 2022-07-19 18-18-26](https://user-images.githubusercontent.com/38990293/179799979-c8f835ff-59e6-4615-ad8d-6a77f1379647.png)
![Screenshot from 2022-07-19 18-18-00](https://user-images.githubusercontent.com/38990293/179799973-68dd29cc-15d8-4bdc-b2fb-3f8b2a6b3575.png)

### New Feature Submissions

* [x] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
https://github.com/CryptoBlades/cryptoblades/issues/1399 **1.6.2**

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

This PR adds exclamation mark to indicate that rewards are depleted in the pool where user staked tokens.

### Testing

Tested locally
