### PR TITLE
Add set hourly income var functionality

### DIFF
--- a/frontend/src/components/smart/AdminTabs/CryptoBladesAdmin.vue
+++ b/frontend/src/components/smart/AdminTabs/CryptoBladesAdmin.vue
@@ -21,11 +21,19 @@
       </b-button>
     </div>
     <h2 class="mt-2">{{ $t('admin.cryptoblades.setFightXpGainCurrentDefault32', {xpGain: currentFightXpGain}) }}</h2>
-    <div class="d-flex align-items-center gap-3">
+    <div class="d-flex align-items-center gap-3 flex-wrap">
       <b-form-input v-model="newFightXpGain" :placeholder="$t('admin.cryptoblades.fightXpGain')" number type="number"/>
       <b-button @click="setNewFightXpGain()" :disabled="setNewFightXpGainButtonDisabled"
                 variant="info" class="text-nowrap">
         {{ $t('admin.cryptoblades.setFightXpGain') }}
+      </b-button>
+    </div>
+    <h2 class="mt-3">{{ $t('admin.cryptoblades.setHourlyIncome', {hourlyIncome: currentHourlyIncome}) }}</h2>
+    <div class="d-flex align-items-center gap-3 flex-wrap">
+      <b-form-input v-model="newHourlyIncome" :placeholder="$t('admin.cryptoblades.hourlyIncome')" number type="number"/>
+      <b-button @click="setNewHourlyIncome()" :disabled="setHourlyIncomeDisabled"
+                variant="info" class="text-nowrap">
+        {{ $t('admin.cryptoblades.setHourlyIncome') }}
       </b-button>
     </div>
   </div>
@@ -48,6 +56,8 @@ interface StoreMappedActions {
   getFightXpGain(): Promise<number>;
 
   setFightXpGain(payload: { xpGain: number }): Promise<void>;
+
+  setHourlyIncome(payload: { hourlyIncome: number }): Promise<void>;
 }
 
 interface Data {
@@ -58,6 +68,8 @@ interface Data {
   currentFightXpGain?: number;
   newFightXpGain?: number;
   isLoading: boolean;
+  currentHourlyIncome?: number;
+  newHourlyIncome?: number;
 }
 
 export default Vue.extend({
@@ -70,6 +82,8 @@ export default Vue.extend({
       currentFightXpGain: undefined,
       newFightXpGain: undefined,
       isLoading: false,
+      currentHourlyIncome: undefined,
+      newHourlyIncome: undefined
     } as Data;
   },
 
@@ -86,6 +100,10 @@ export default Vue.extend({
       return this.newFightXpGain === undefined
         || this.isLoading;
     },
+    setHourlyIncomeDisabled(): boolean {
+      return this.newHourlyIncome === undefined
+        || this.isLoading;
+    },
   },
 
   methods: {
@@ -96,6 +114,7 @@ export default Vue.extend({
       'getWeaponMintValue',
       'getFightXpGain',
       'setFightXpGain',
+      'setHourlyIncome',
     ]) as StoreMappedActions,
 
     async setNewCharacterMintValue() {
@@ -129,6 +148,18 @@ export default Vue.extend({
         await this.setFightXpGain({xpGain: this.newFightXpGain!});
         await this.loadCurrentValues();
         this.newFightXpGain = undefined;
+      } finally {
+        this.isLoading = false;
+      }
+    },
+
+    async setNewHourlyIncome() {
+      if (this.setHourlyIncomeDisabled) return;
+      try {
+        this.isLoading = true;
+        await this.setHourlyIncome({hourlyIncome: this.newHourlyIncome!});
+        await this.loadCurrentValues();
+        this.newHourlyIncome = undefined;
       } finally {
         this.isLoading = false;
       }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -959,7 +959,9 @@
       "newValueInCents": "New value (in cents)",
       "setFightXpGainCurrentDefault32": "Set fight XP gain (current: {xpGain} xp, default: 32 xp)",
       "setFightXpGain": "Set fight XP gain",
-      "fightXpGain": "Fight XP gain"
+      "fightXpGain": "Fight XP gain",
+      "setHourlyIncome": "Set hourly income",
+      "hourlyIncome": "Hourly income"
     },
     "blacksmith": {
       "setFlatPriceOfItem": "Set flat price of item",

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -2332,7 +2332,7 @@ export default new Vuex.Store<IState>({
 
       const VAR_HOURLY_INCOME = await CryptoBlades.methods.VAR_HOURLY_INCOME().call(defaultCallOptions(state));
 
-      return await CryptoBlades.methods.setVar(VAR_HOURLY_INCOME, state.web3.utils.toBN(hourlyIncome * 10 ** 18).toString())
+      return await CryptoBlades.methods.setVar(VAR_HOURLY_INCOME, Web3.utils.toWei(hourlyIncome.toString(), 'ether').toString())
         .send({from: state.defaultAccount, gasPrice: getGasPrice()});
     },
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -2332,7 +2332,7 @@ export default new Vuex.Store<IState>({
 
       const VAR_HOURLY_INCOME = await CryptoBlades.methods.VAR_HOURLY_INCOME().call(defaultCallOptions(state));
 
-      return await CryptoBlades.methods.setVar(VAR_HOURLY_INCOME, hourlyIncome)
+      return await CryptoBlades.methods.setVar(VAR_HOURLY_INCOME, state.web3.utils.toBN(hourlyIncome * 10 ** 18).toString())
         .send({from: state.defaultAccount, gasPrice: getGasPrice()});
     },
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -2326,6 +2326,16 @@ export default new Vuex.Store<IState>({
       });
     },
 
+    async setHourlyIncome({state}, {hourlyIncome}) {
+      const {CryptoBlades} = state.contracts();
+      if(!state.defaultAccount || !CryptoBlades) return;
+
+      const VAR_HOURLY_INCOME = await CryptoBlades.methods.VAR_HOURLY_INCOME().call(defaultCallOptions(state));
+
+      return await CryptoBlades.methods.setVar(VAR_HOURLY_INCOME, hourlyIncome)
+        .send({from: state.defaultAccount, gasPrice: getGasPrice()});
+    },
+
     async getRaidXpReward({state}) {
       const {Raid1} = state.contracts();
       if (!Raid1) return;


### PR DESCRIPTION
### All Submissions

* [x] Can you post a screenshot of your changes (if applicable)?

![Screenshot from 2022-07-19 20-04-06](https://user-images.githubusercontent.com/38990293/179819391-836de8cf-2ab8-4984-baa6-a1119909bda6.png)


### New Feature Submissions

* [x] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
https://github.com/CryptoBlades/cryptoblades/issues/1533

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

This PR adds functionality to set hourly income var in the Cryptoblades contract

### Testing

I set value `123` via admin panel end checked it on the blockchain:
```
truffle(development)> (await cryptoblades.vars(1)).toString();
'123000000000000000000'
```
