### PR TITLE
Fix blacksmith initial load

### DIFF
--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -752,7 +752,6 @@ export default Vue.extend({
       return this.currentFilteredWeapons.map(w => w.id);
     },
     totalSkillBalance(): BN {
-      console.log(toBN(fromWeiEther(this.skillRewards)).plus(toBN(fromWeiEther(this.inGameOnlyFunds))).plus(toBN(fromWeiEther(this.skillBalance))).toString());
       return toBN(fromWeiEther(this.skillRewards)).plus(toBN(fromWeiEther(this.inGameOnlyFunds))).plus(toBN(fromWeiEther(this.skillBalance)));
     },
 
@@ -1028,7 +1027,6 @@ export default Vue.extend({
       const currentFilteredForBuringIds = this.currentFilteredWeaponsIds.filter(id => this.burnWeaponIds.includes(id));
       if(currentFilteredForBuringIds.length > 0){
         currentFilteredForBuringIds.forEach(id => {
-          console.log(id);
           this.ctr += 1;
           const weaponDetails = this.ownWeapons.find(y => {
             if(y && +y.id === +id){

--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -896,6 +896,9 @@ export default Vue.extend({
         this.selectedElement = null;
         this.showModal = false;
         this.spin = false;
+        //refresh forge data
+        this.isLoading = true;
+        this.updateForgeData();
       }
     },
 


### PR DESCRIPTION
- resolves #1548


updateMintWeaponFee() is called every 2 seconds. Initially, there is an error, because state.defaultAccount isn't set. This means that we get the data after >2s the earliest. 
Polling and not waiting for a state change is bad. Takes long and throws errors.
- removed the whole interval thing
- updateMintWeaponFee() is now updateForgeData() and includes forgeCost, skillForgeCost, reforgeCost, stakedBalanceThatCanBeSpent, fetchSpecialWeapons() etc.
- watching state.defaultAccount from store (using that as a flag in general is a good idea, because this presupposes that contracts are set as well)
- if state.defaultAccount changes from null -> something, we can fetch and display the data safely in <.5s and don't need guards 
- moved the calls from created() to updateForgeData() (same reason)
- updateForgeData() is called after forging as well
- removed console.logs