### PR TITLE
Fix: 1568

### DIFF
--- a/frontend/src/views/Bridge.vue
+++ b/frontend/src/views/Bridge.vue
@@ -519,6 +519,8 @@ export default Vue.extend({
     }
   },
   async mounted(){
+    await this.getBridgeFee();
+    await this.getIncoming();
     await this.showStorage();
     this.refreshIntervall = window.setInterval(async () => await this.showStorage(), 5000);
   },

--- a/frontend/src/views/Bridge.vue
+++ b/frontend/src/views/Bridge.vue
@@ -519,8 +519,10 @@ export default Vue.extend({
     }
   },
   async mounted(){
-    await this.getBridgeFee();
-    await this.getIncoming();
+    if(this.defaultAccount && this.contracts){
+      this.getBridgeFee();
+      this.getIncoming();
+    }
     await this.showStorage();
     this.refreshIntervall = window.setInterval(async () => await this.showStorage(), 5000);
   },


### PR DESCRIPTION
- Small fix for loading the bridge fee https://github.com/CryptoBlades/cryptoblades/pull/1568

Mistake by me: 
- The calls that we need to do on load need to be called in mounted() / created() (for the case that someone navigates to the view (contracts / defaultaccount are set there and the app is already initialized)) AND need to be made from a watcher (for the case that a user refreshes the page on that view and we need to wait for defaultAccount / contracts to be initialized)