### PR TITLE
fix 10x forge button skill cost

### DIFF
--- a/frontend/src/components/BlacksmithNav.vue
+++ b/frontend/src/components/BlacksmithNav.vue
@@ -37,7 +37,7 @@
           <cb-button class="custom-cb-btn custom-forge-btn gtag-link-others" tagname="weapon_forge_multiple"
             :title="`${disableForge ? $t('blacksmith.coolingForge') : $t('blacksmith.forge')} x10 <br/>`"
             :isLoading="isLoading"
-            :subTitle="`(${forgeCost === '0' ? '0.0000' : forgeCost} SKILL)`" @clickEvent="$emit('onClickForge', 1)"
+            :subTitle="`(${forgeCost === '0' ? '0.0000' : (forgeCost*10).toFixed(4)} SKILL)`" @clickEvent="$emit('onClickForge', 1)"
             :isDisabled="disableX10Forge || disableForge || (disableX10ForgeWithStaked && useStakedForForge)"
             :toolTip="(disableX10Forge) ? $t('blacksmith.disableDynamicMintingForge') : $t('blacksmith.forge10New')"
             :style="disableX10Forge ? 'opacity: 0.5' : ''"


### PR DESCRIPTION
Since the UI was redesigned, the forge fee displayed on the 1x mint btn was === fee displayed on the 10x mint btn.

Before:
![image](https://user-images.githubusercontent.com/5601589/185479825-22cc6aeb-7a76-4889-ae0f-5b826ae926f2.png)
Now:
![image](https://user-images.githubusercontent.com/5601589/185479878-38ab84f9-ab01-4f18-b935-84e475111808.png)


