### PR TITLE
Raid over/restarting information on frontend

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -590,6 +590,7 @@
     "nextRaid" : "Next Raid",
     "finishesOn": "Finishes on",
     "raidStatus": "Raid status",
+    "raidOver": "Next raid starting soon",
     "claimRewards": "Claim rewards",
     "raidRewardsSelector": "Raid rewards selector",
     "selectRaid": "Select a raid to claim rewards from",

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -113,8 +113,11 @@
                   <span class="raid-boss-value" v-if="this.remainingTime.hours > 0">
                     {{this.remainingTime.hours}}:{{this.remainingTime.minutes}}:{{this.remainingTime.seconds}}
                   </span>
-                  <span class="raid-boss-value" v-else>
+                  <span class="raid-boss-value" v-else-if="remainingTime.seconds > -1 && remainingTime.minutes > -1">
                     {{this.remainingTime.minutes}}:{{this.remainingTime.seconds}}
+                  </span>
+                  <span class="raid-boss-value" v-else>
+                    {{$t('raid.raidOver')}}
                   </span>
                 </span>
               </div>

--- a/frontend/src/views/Raid.vue
+++ b/frontend/src/views/Raid.vue
@@ -40,40 +40,45 @@
                     <p class="no-margin" v-else>{{$t('raid.noPendingRaid')}}</p>
 
                     <div class="w-limit" v-if="raidStatus==='0'">
-                        <div class="day">
-                          <p>00</p>
-                          <span>{{ remainingTime.days > 1 ? $t('raid.days') : $t('raid.day') }}</span>
-                        </div>
-                        <div class="hour">
-                          <p>00</p>
-                          <span>{{ remainingTime.hours > 1 ? $t('raid.hrs') : $t('raid.hr')}}</span>
-                        </div>
-                        <div class="min">
-                          <p>00</p>
-                          <span>{{ remainingTime.minutes > 1 ? $t('raid.mins') : $t('raid.min')}}</span>
-                        </div>
-                        <div class="sec">
-                          <p>00</p>
-                          <span>{{ remainingTime.seconds > 1 ? $t('raid.sec') : $t('raid.sec')}}</span>
-                        </div>
+                      <div class="day">
+                        <p>00</p>
+                        <span>{{ remainingTime.days > 1 ? $t('raid.days') : $t('raid.day') }}</span>
+                      </div>
+                      <div class="hour">
+                        <p>00</p>
+                        <span>{{ remainingTime.hours > 1 ? $t('raid.hrs') : $t('raid.hr')}}</span>
+                      </div>
+                      <div class="min">
+                        <p>00</p>
+                        <span>{{ remainingTime.minutes > 1 ? $t('raid.mins') : $t('raid.min')}}</span>
+                      </div>
+                      <div class="sec">
+                        <p>00</p>
+                        <span>{{ remainingTime.seconds > 1 ? $t('raid.sec') : $t('raid.sec')}}</span>
+                      </div>
+                    </div>
+                    <div class="w-limit" v-else-if="remainingTime.seconds > -1 && remainingTime.minutes > -1">
+                      <div class="day" v-if="remainingTime.days > 0">
+                        <p>{{ zeroPad(remainingTime.days, 2) }}</p>
+                        <span>{{ remainingTime.days > 1 ? $t('raid.days') : $t('raid.day') }}</span>
+                      </div>
+                      <div class="hour" v-if="remainingTime.hours > 0">
+                        <p>{{ zeroPad(remainingTime.hours, 2)}}</p>
+                        <span>{{ remainingTime.hours > 1 ? $t('raid.hrs') : $t('raid.hr')}}</span>
+                      </div>
+                      <div class="min">
+                        <p>{{ zeroPad(remainingTime.minutes, 2)}}</p>
+                        <span>{{ remainingTime.minutes > 1 ? $t('raid.mins') : $t('raid.min')}}</span>
+                      </div>
+                      <div class="sec">
+                        <p>{{ zeroPad(remainingTime.seconds, 2)}}</p>
+                        <span>{{ remainingTime.seconds > 1 ? $t('raid.sec') : $t('raid.sec')}}</span>
+                      </div>
                     </div>
                     <div class="w-limit" v-else>
-                        <div class="day" v-if="remainingTime.days > 0">
-                          <p>{{ zeroPad(remainingTime.days, 2) }}</p>
-                          <span>{{ remainingTime.days > 1 ? $t('raid.days') : $t('raid.day') }}</span>
-                        </div>
-                        <div class="hour" v-if="remainingTime.hours > 0">
-                          <p>{{ zeroPad(remainingTime.hours, 2)}}</p>
-                          <span>{{ remainingTime.hours > 1 ? $t('raid.hrs') : $t('raid.hr')}}</span>
-                        </div>
-                        <div class="min">
-                          <p>{{ zeroPad(remainingTime.minutes, 2)}}</p>
-                          <span>{{ remainingTime.minutes > 1 ? $t('raid.mins') : $t('raid.min')}}</span>
-                        </div>
-                        <div class="sec">
-                          <p>{{ zeroPad(remainingTime.seconds, 2)}}</p>
-                          <span>{{ remainingTime.seconds > 1 ? $t('raid.sec') : $t('raid.sec')}}</span>
-                        </div>
+                      <div class="raidNotStarted">
+                        <p>{{$t('raid.raidOver')}}</p>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1697,10 +1702,14 @@ hr.divider {
 
 .w-limit > div{
   width: 5em;
-    justify-content: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.w-limit > div.raidOver {
+  width: inherit;
 }
 
 .boss-name > div{


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
Closes #1616

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Remove possibility of negative numbers showing up in raid countdown. When it goes negative, display message to user that the next raid is being readied, assuming raidStatus isn't 0 (unstarted)

### Testing

Has the code been tested, or does it need double checking?
