### PR TITLE
Fight gas optimizations (pre-octoblades)

### DIFF
--- a/contracts/characters.sol
+++ b/contracts/characters.sol
@@ -355,8 +355,8 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
 
     function getFightDataAndDrainStamina(address fighter,
         uint256 id, uint8 amount, bool allowNegativeStamina, uint256 busyFlag) public restricted returns(uint96) {
-        require(fighter == ownerOf(id) && nftVars[id][NFTVAR_BUSY] == 0);
-        nftVars[id][NFTVAR_BUSY] |= busyFlag;
+        require(fighter == ownerOf(id)/* && nftVars[id][NFTVAR_BUSY] == 0*/);
+        //nftVars[id][NFTVAR_BUSY] |= busyFlag;
 
         Character storage char = tokens[id];
         uint8 staminaPoints = getStaminaPointsFromTimestamp(char.staminaTimestamp);

--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -363,15 +363,9 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
         uint24 playerRoll = getPlayerPowerRoll(data.playerFightPower,data.traitsCWE,seed);
         uint24 monsterRoll = getMonsterPowerRoll(data.targetPower, RandomUtil.combineSeeds(seed,1));
 
-        updateHourlyPayouts(); // maybe only check in trackIncome? (or do via bot)
-
         uint16 xp = getXpGainForFight(data.playerFightPower, data.targetPower) * fightMultiplier;
         tokens = getTokenGainForFight(data.targetPower, true) * fightMultiplier;
         expectedTokens = tokens;
-
-        if(tokenRewards[fighter] == 0 && tokens > 0) {
-            _rewardsClaimTaxTimerStart[fighter] = block.timestamp;
-        }
 
         if (playerRoll < monsterRoll) {
             tokens = 0;
@@ -380,13 +374,7 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
         // this may seem dumb but we want to avoid guessing the outcome based on gas estimates!
         tokenRewards[fighter] += tokens;
-        vars[VAR_UNCLAIMED_SKILL] += tokens;
-        vars[VAR_HOURLY_DISTRIBUTION] -= tokens;
         xpRewards[char] += xp;
-
-
-        vars[VAR_HOURLY_FIGHTS] += fightMultiplier;
-        vars[VAR_HOURLY_POWER_SUM] += data.playerFightPower * fightMultiplier;
 
         emit FightOutcome(fighter, char, wep, (data.targetPower | ((uint32(data.traitsCWE) << 8) & 0xFF000000)), playerRoll, monsterRoll, xp, tokens);
     }
@@ -397,18 +385,11 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
 
     function getTokenGainForFight(uint24 monsterPower, bool applyLimit) public view returns (uint256) {
         // monsterPower / avgPower * payPerFight * powerMultiplier
-        uint256 amount = ABDKMath64x64.divu(monsterPower, vars[VAR_HOURLY_POWER_AVERAGE])
-            .mulu(vars[VAR_HOURLY_PAY_PER_FIGHT]);
-
-        if(amount > vars[VAR_PARAM_MAX_FIGHT_PAYOUT])
-            amount = vars[VAR_PARAM_MAX_FIGHT_PAYOUT];
-        if(vars[VAR_HOURLY_DISTRIBUTION] < amount * 5 && applyLimit) // the * 5 is a temp measure until we can sync frontend on main
-            amount = 0;
-        return amount;
+        return monsterPower * vars[VAR_HOURLY_PAY_PER_FIGHT] / vars[VAR_HOURLY_POWER_AVERAGE];
     }
 
     function getXpGainForFight(uint24 playerPower, uint24 monsterPower) internal view returns (uint16) {
-        return uint16(ABDKMath64x64.divu(monsterPower, playerPower).mulu(fightXpGain));
+        return uint16(monsterPower * fightXpGain / playerPower);
     }
 
     function getPlayerPowerRoll(

--- a/contracts/weapons.sol
+++ b/contracts/weapons.sol
@@ -697,8 +697,8 @@ contract Weapons is Initializable, ERC721Upgradeable, AccessControlUpgradeable {
         bool allowNegativeDurability,
         uint256 busyFlag
     ) public restricted returns (int128, int128, uint24, uint8) {
-        require(fighter == ownerOf(id) && nftVars[id][NFTVAR_BUSY] == 0);
-        nftVars[id][NFTVAR_BUSY] |= busyFlag;
+        require(fighter == ownerOf(id)/* && nftVars[id][NFTVAR_BUSY] == 0*/);
+        //nftVars[id][NFTVAR_BUSY] |= busyFlag;
         drainDurability(id, drainAmount, allowNegativeDurability);
         Weapon storage wep = tokens[id];
         return (

--- a/migrations/193_fightop_preoctoblades.js
+++ b/migrations/193_fightop_preoctoblades.js
@@ -1,0 +1,23 @@
+const { upgradeProxy, deployProxy } = require("@openzeppelin/truffle-upgrades");
+const CryptoBlades = artifacts.require("CryptoBlades");
+const Characters = artifacts.require("Characters");
+const Weapons = artifacts.require("Weapons");
+
+module.exports = async function (deployer, network, accounts) {
+    if (network === "development"
+    || network === "development-fork"
+    || network === 'bsctestnet'
+    || network === 'bsctestnet-fork'
+    || network === 'hecotestnet'
+    || network === 'okextestnet'
+    || network === 'polygontestnet'
+    || network === 'avaxtestnet'
+    || network === 'avaxtestnet-fork'
+    || network === 'auroratestnet'
+    || network === 'kavatestnet'
+    || network === 'skaletestnet') {
+        await upgradeProxy(CryptoBlades.address, CryptoBlades, { deployer });
+        await upgradeProxy(Characters.address, Characters, { deployer });
+        await upgradeProxy(Weapons.address, Weapons, { deployer });
+    }
+};


### PR DESCRIPTION
Removed analytics, old claim tax hook and busy var checks from fights. Simplified the token/xp calculations.
On dev, this takes fight cost down from 126k to about 86k. On Prod, gas costs are higher by some degree (30-40%), so the final impact is not clear at this time but could be up to 30% cost reduction.