### PR TITLE
FIX: app contents pushed to bottom of screen at smaller widths

### DIFF
--- a/frontend/src/components/smart/CharacterDisplay.vue
+++ b/frontend/src/components/smart/CharacterDisplay.vue
@@ -393,7 +393,6 @@ export default Vue.extend({
 
 .character-display-container {
   margin-top: -20px;
-  height: 90vh;
 }
 
 


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
Closes #1621 

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

CharacterDisplay unnecessarily pushes screen contents out of view. Inherited height fits plaza characters/calculator already and requires less scrolling to get to app contents.

### Testing

Has the code been tested, or does it need double checking?
