### PR TITLE
exposed matchability checks in pvp core

### DIFF
--- a/contracts/PvpCore.sol
+++ b/contracts/PvpCore.sol
@@ -823,6 +823,14 @@ contract PvpCore is Initializable, AccessControlUpgradeable {
         return _matchableCharactersByTier[tier].length();   
     }
 
+    function getMatchablePlayerCountByTier(uint8 tier) external view returns (uint) {
+        return _matchableCharactersByTier[tier].length();
+    }
+
+    function isCharacterMatchableByTier(uint256 characterID, uint8 tier) external view returns (bool) {
+        return _matchableCharactersByTier[tier].contains(characterID);
+    }
+
     function _getPVPTraitBonusAgainst(
         uint8 characterTrait,
         uint8 weaponTrait,

--- a/migrations/202_pvp_info_expose.js
+++ b/migrations/202_pvp_info_expose.js
@@ -1,0 +1,6 @@
+const { upgradeProxy, deployProxy } = require("@openzeppelin/truffle-upgrades");
+const PvpCore = artifacts.require("PvpCore");
+
+module.exports = async function (deployer, network, accounts) {
+    await upgradeProxy(PvpCore.address, PvpCore, { deployer });
+};


### PR DESCRIPTION
this is to help the pvp player bot,
but also allows for checking player counts before joining the arena, something no doubt many players would like to do before spending gas to join.
