### PR TITLE
Remove octoblades IGO

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -385,11 +385,6 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
             tokens = 0;
             xp = 0;
         }
-        //TEMP FOR EVENT
-        else {
-            _giveInGameOnlyFundsFromContractBalance(fighter, vars[VAR_FIGHT_FLAT_IGO_BONUS] * fightMultiplier);
-        }
-        //^ TEMP
 
         if(characterVersion > 0) {
             userVars[fighter][USERVAR_GEN2_UNCLAIMED] += tokens;

--- a/migrations/205_remove_octoblades_igo.js
+++ b/migrations/205_remove_octoblades_igo.js
@@ -1,0 +1,12 @@
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+
+const CryptoBlades = artifacts.require("CryptoBlades");
+
+module.exports = async function (deployer, network) {
+    const game = await CryptoBlades.deployed();
+    if(network === 'bscmainnet') {
+        const VAR_FIGHT_FLAT_IGO_BONUS = await game.VAR_FIGHT_FLAT_IGO_BONUS();
+        await game.setVar(VAR_FIGHT_FLAT_IGO_BONUS, 0);
+    }
+    await upgradeProxy(CryptoBlades.address, CryptoBlades, { deployer });
+};


### PR DESCRIPTION
### PR Description

Removing IGO code to save users gas on BSC

### Notes

The var needs to be set to 0, otherwise the modal will show up with the last set value. The feature will no doubt return in the future though, so we should not undo the frontend half of this, since it knows to ignore it when 0.

### Testing

Tested.
