### PR TITLE
Implemented dynamic IGO for #1796

### DIFF
--- a/contracts/cryptoblades.sol
+++ b/contracts/cryptoblades.sol
@@ -385,6 +385,9 @@ contract CryptoBlades is Initializable, AccessControlUpgradeable {
             tokens = 0;
             xp = 0;
         }
+        else if (vars[VAR_FIGHT_FLAT_IGO_BONUS] > 0) {
+            _giveInGameOnlyFundsFromContractBalance(fighter, vars[VAR_FIGHT_FLAT_IGO_BONUS] * fightMultiplier);
+        }
 
         if(characterVersion > 0) {
             userVars[fighter][USERVAR_GEN2_UNCLAIMED] += tokens;

--- a/migrations/208_dynamic_igo.js
+++ b/migrations/208_dynamic_igo.js
@@ -1,0 +1,7 @@
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+
+const CryptoBlades = artifacts.require("CryptoBlades");
+
+module.exports = async function (deployer, network) {
+    await upgradeProxy(CryptoBlades.address, CryptoBlades, { deployer });
+};


### PR DESCRIPTION
### Please check migration numbers before merging

### PR Description

Based on ticket #1796
Implements a lightweight if-clause to distribute IGO.
Previously we would not do an if check in the else branch and would incur a hefty gas cost of modifying the user's IGO value to itself (you still pay extra even if the number doesn't change)
This solution makes very little impact but saves a LOT of gas when it's set to 0 and allows us to have different gas impact per-network.

Operating the feature is same as before, modifying var 28 on the cryptoblades contract.

### Testing

Tested locally

Before if clause
win	103217 << extra cost for writing earnings on character for first time
win	87645 << real value to compare
After if clause, 0 amount
win	87883
win	87883
After if clause, non-0 amount
win	110433 << extra cost for taking user's IGO amount from 0 to non-0
win	95297 << consecutive gas cost compared to above for updating IGO number

Seems only 238 gas cost for the if clause. That's very negligible even at BNB ATH.

