### PR TITLE
added pause support to DEX

### DIFF
--- a/contracts/Dex.sol
+++ b/contracts/Dex.sol
@@ -16,6 +16,7 @@ contract Dex is Initializable, AccessControlUpgradeable {
     uint public constant FEE_DENOMINATOR = 10000;
 
     uint8 public constant VAR_FEE = 0;
+    uint8 public constant VAR_CONTRACT_ENABLED = 1;
 
     struct TokenPair {
         address token1;
@@ -47,9 +48,18 @@ contract Dex is Initializable, AccessControlUpgradeable {
         require(hasRole(GAME_ADMIN, msg.sender) || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "NA");
     }
 
+    modifier contractEnabled() {
+        _contractEnabled();
+        _;
+    }
+
+    function _contractEnabled() internal view {
+        require(vars[VAR_CONTRACT_ENABLED] == 1, "Contract disabled");
+    }
+
     // FUNCTIONS
 
-    function swap(address tokenA, address tokenB, uint amountA) external {
+    function swap(address tokenA, address tokenB, uint amountA) external contractEnabled {
         uint id = getTokenPairId(tokenA, tokenB);
         TokenPair memory pair = tokenPairs[id];
         require((pair.token1 == tokenA && pair.token2 == tokenB) || (pair.token2 == tokenA && pair.token1 == tokenB), "Invalid pair");

--- a/migrations/209_dex_access.js
+++ b/migrations/209_dex_access.js
@@ -1,0 +1,9 @@
+const { upgradeProxy } = require("@openzeppelin/truffle-upgrades");
+
+const Dex = artifacts.require("Dex");
+
+module.exports = async function (deployer) {
+    await upgradeProxy(Dex.address, Dex, { deployer });
+    // This upgrade adds the variable VAR_CONTRACT_ENABLED to toggle access (0 = off, 1 = on),
+    // It's left off by default out of caution
+};


### PR DESCRIPTION
### PR Description

I was informed the contract urgently needs a pause function, this is the implementation (using a var instead of the pasuable interface out of preference)

### Testing

Not tested, though the code was copied from simplequests.sol and merely renamed, so it should be fine. Either way the contract is disabled by default
