### PR TITLE
Experience Claim Optimization issues #1787 - features

### DIFF
--- a/contracts/characters.sol
+++ b/contracts/characters.sol
@@ -329,25 +329,70 @@ contract Characters is Initializable, ERC721Upgradeable, AccessControlUpgradeabl
         return tokens[id].xp;
     }
 
-    function gainXp(uint256 id, uint16 xp) public restricted {
+    function gainXp(uint256 id, uint256 xp) public restricted {
         _gainXp(id, xp);
     }
 
     function _gainXp(uint256 id, uint256 xp) internal {
         // NOTE: Levelups invalidate power data, but recalculating is optional
         Character storage char = tokens[id];
-        if (char.level < 255) {
-            uint newXp = char.xp.add(xp);
-            uint requiredToLevel = experienceTable[char.level]; // technically next level
-            while (newXp >= requiredToLevel) {
-                newXp = newXp - requiredToLevel;
-                char.level += 1;
-                emit LevelUp(ownerOf(id), id, char.level);
-                if (char.level < 255)
-                    requiredToLevel = experienceTable[char.level];
-                else newXp = 0;
-            }
+        if (char.level < 20){
+            _oldXpOptimized(id, xp);
+        }else if(char.level >= 20 && char.level < 255){
+            _mergeSearch(id, xp);
+        } 
+    }
+    
+    function _oldXpOptimized(uint256 id, uint256 xp) internal returns(uint256){
+        Character storage char = tokens[id];
+        uint newXp = char.xp + xp;
+        uint requiredToLevel = experienceTable[char.level]; // technically next level
+        while (newXp >= requiredToLevel && char.level < 20) {
+            newXp = newXp - requiredToLevel;
+            char.level += 1;
+            requiredToLevel = experienceTable[char.level];
+        }
+        if(char.level >= 20 && newXp >= requiredToLevel){
+            _mergeSearch(id,newXp);
+        }else{
             char.xp = uint16(newXp);
+            emit LevelUp(ownerOf(id), id, char.level);
+        }
+        
+    }
+    function calculateCumSum(uint level, uint n) internal view returns(uint256){
+        uint innerPart = n > 28 ? 3*level*level + 935 + 3*level*(n - 28) + n*n - 42*n  : 3*level*level + 935 - 3*level*(28 - n) + n*n - 42*n ;
+        uint cumSum = (n*innerPart)/6;
+        return cumSum;
+    }
+    
+    function _mergeSearch(uint256 id, uint256 exp) public returns(uint16){
+        Character storage char = tokens[id];
+        uint8 level = char.level;
+        if(level < 255){
+            uint16 upperBound = uint16(exp/(((level-19)*(level-19) + 11*(level-19) + 146)/2)); 
+            uint16 n = upperBound;
+            uint16 currentExp = char.xp;
+            uint256 cumSum = calculateCumSum(level, upperBound);
+            while(cumSum > exp - currentExp){
+                n = n/2;
+                cumSum = calculateCumSum(level, n);
+            }
+            uint16 i;
+            for(i=n; i < upperBound; i++){
+                cumSum = calculateCumSum(level, i);
+                if(cumSum > exp - currentExp || level + i > 255){
+                    console.log("It's TOO BIG");
+                    i = i - 1;
+                    break;
+                }
+            }
+            cumSum = calculateCumSum(level, i);
+            uint16 exceedingXp = uint16(exp - cumSum + currentExp);
+            char.level += uint8(i);
+            char.level == 255 ? char.xp = 0 : char.xp = exceedingXp;
+            emit LevelUp(ownerOf(id), id, char.level);
+            return i;
         }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -46,6 +46,14 @@ contract('Characters', accounts => {
   });
 
   describe('gainXp', () => {
+
+    beforeEach(async () => {
+      await characters.mint(accounts[0], '123');
+
+      const events = await characters.getPastEvents();
+      assertEventEmitted(events, 'NewCharacter', 0);
+    });
+  
     it('should work', async () => {
       await characters.mint(accounts[0], '123');
 
@@ -60,6 +68,39 @@ contract('Characters', accounts => {
 
       assert.strictEqual(lv.toString(), '23');
       assert.strictEqual(xp.toString(), '22');
+    });
+
+    it('should level up from 1-55', async () => {
+      await characters.gainXp(0, 15000);
+
+      const [lv, xp] = await Promise.all([
+        characters.getLevel(0), characters.getXp(0)
+      ]);
+
+      assert.strictEqual(lv.toString(), '55');
+      assert.strictEqual(xp.toString(), '822');
+    });
+
+    it('should level up from 20-56', async () => {
+      await characters.gainXp(0, 15000);
+
+      const [lv, xp] = await Promise.all([
+        characters.getLevel(0), characters.getXp(0)
+      ]);
+
+      assert.strictEqual(lv.toString(), '56');
+      assert.strictEqual(xp.toString(), '606');
+    });
+
+    it('should level up from 1-255', async () => {
+      await characters.gainXp(0, 2347194);
+
+      const [lv, xp] = await Promise.all([
+        characters.getLevel(0), characters.getXp(0)
+      ]);
+
+      assert.strictEqual(lv.toString(), '255');
+      assert.strictEqual(xp.toString(), '0');
     });
   });
 


### PR DESCRIPTION
### All Submissions

### New Feature Submissions

Related to issues #1787 

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description
#### Legend
```
l = level
n = indicates for how many levels forward you need to calculate the cumulative sum
k = claimable char experience
```
In this PR, I propose a solution to lower the gas fees substantially. The code takes its cue from Binary Search. The idea is that past level 20 the code is described by an arithmetic series $(l-19)^2 + 11(l-19) + 146)/2$, hence we can know a priori each step without having to access the experienceTable. By taking the summation of this series: 
$\sum (x^2 + 11x + 146)/2$ `from x=l-19 to n+l-20` $= (n/6)(3 l^2 + 3 l (n - 28) + n^2 - 42 n + 935)$. 
(Sorry tried to put from and to in the sum, but doesn't work properly with markup).
With this formula we can know a priori the cumulative sum given a level l and a step n. The big optimization lies in this line here:
```uint16 upperBound = uint16(exp/(((level-19)*(level-19) + 11*(level-19) + 146)/2));```
where we calculate the maximum number of times that we are allowed to look for. In this way we can check if the cumulative sum at that upperBound $cumSum[upperBound] < k$ and checking going iteratively up to see when the $cumSum[upperBound] > k$ and we stop.

If instead $upperBound >k$ we just $upperBound/2$ in order to optimize the search and making this algorithm `O(log(n))` computation wise and `O(1)` memory wise (This stands only for the `_mergeSearch` algorithm of my implementation). 

This improvement reduces the gas cost for (I'm using compiler optimization):
* 1-55 (15k exp) from 310k to 120k
* 20-56 (15k exp) from 220k to 66k
* 1-255 (2347194 exp) from 1.3M to 117k

Take into account that the algorithm goes beyond 100k gas when it has to use the old algorithm from 1-20 (since there is no arithmetic series that describes it).
I've made just a few improvements for the old algorithm, since it was emitting too many events.

I've changed also the uint type for `gainXp(uint256 id, uint16 xp)`=>  `gainXp(uint256 id, uint256 xp)`, since it currently doesn't allow someone to claim more than 2^16 exp, causing overflow.
### Testing

The code has been tested multiple times and I've made some test cases too. But feel free and please do test it again.

I haven't used safeMath, since the math itself can’t overflow or underflow.
### Possible other improvements

In order to further lower the cost there are two possible solutions:

1. In a pythonic way: `experienceTable[:20]` in order to lower the storage cost, since all the rest of the values are computed with the formula. It can be created an auxiliary pure function to calculate the experience needed at each level.
2. The whole experience can be changed into a geometric series, rather than arithmetic (so to make it increasingly more difficult to level up, like now), but with this improvements we don't have to rely on the old `_gainXp` function and thus the cost should always be around 60-80k gas.
