### PR TITLE
Fix the infinity xp bug by dispatching the fetchPowerData call when updating character weapons.

### DIFF
--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -1080,7 +1080,7 @@ export default new Vuex.Store<IState>({
       await dispatch('fetchKeyLootboxes', ownedKeyLootboxIds);
     },
 
-    async updateCharacterWeapons({ state }) {
+    async updateCharacterWeapons({ state, dispatch }) {
       if(!state.defaultAccount) return;
 
       const equipment = state.contracts().EquipmentManager!;
@@ -1098,6 +1098,8 @@ export default new Vuex.Store<IState>({
           Vue.set(state.characterWeapons, charId, undefined);
         }
       }
+
+      await dispatch('fetchPowerData', charId);
     },
 
     async fetchCharacterWeapon({ state }, characterId: string | number) {

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -1092,14 +1092,14 @@ export default new Vuex.Store<IState>({
           const equippedWeapon = await equipment.methods.equippedSlotID(characters.options.address, charId, 1).call(defaultCallOptions(state));
           Vue.set(state.characterWeapons, charId, equippedWeapon);
           console.log('got weapon: '+equippedWeapon);
+
+          await dispatch('fetchPowerData', charId);
         }
         else {
           console.log('no weapon');
           Vue.set(state.characterWeapons, charId, undefined);
         }
       }
-
-      await dispatch('fetchPowerData', charId);
     },
 
     async fetchCharacterWeapon({ state }, characterId: string | number) {


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?

Before:
![image](https://user-images.githubusercontent.com/41158626/224181271-acb2a60f-4ecf-435b-b8f2-97cbfb712bd0.png)

After:
![image](https://user-images.githubusercontent.com/41158626/224180948-787d21e6-337d-4f74-b1a6-a55e57fb8084.png)


### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
https://github.com/CryptoBlades/cryptoblades/issues/1873

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Solves the infinity XP bug in the issue mentioned above. 

The powerData would contain zeros in the following scenario:
1. Recruit a new character.
2. Equip a weapon.
3. Move to the adventure tab (Without in between refreshes).

### Testing

Has the code been tested, or does it need double checking?

Has been tested by myself, maybe that it would be neater to only dispatch this call when equiping a weapon instead of also dispatching it on unequip calls.
