### PR TITLE
Fix the LB/4B & 5B dusting reforge slider max values.

### DIFF
--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -372,11 +372,11 @@
                   </div>
                 </div>
                 <div>
-                  <input v-model="lesserDust" type="range" min="0" :max="getLesserDust()" value="0" steps="1">
+                  <input v-model="lesserDust" type="range" min="0" :max="100" value="0" steps="1">
                 </div>
                 <div>
                   <span>{{lesserDust}}/{{getLesserDust()}}</span>
-                  <span class="cursor-p" @click="lesserDust = getLesserDust()">{{$t('blacksmith.max')}}</span>
+                  <span class="cursor-p" @click="lesserDust = 100">{{$t('blacksmith.max')}}</span>
                 </div>
               </div>
 
@@ -392,11 +392,11 @@
                   </div>
                 </div>
                 <div>
-                  <input v-model="greaterDust" type="range" min="0" :max="getGreaterDust()" value="0" steps="1">
+                  <input v-model="greaterDust" type="range" min="0" :max="25" value="0" steps="1">
                 </div>
                 <div>
                   <span>{{greaterDust}}/{{getGreaterDust()}}</span>
-                  <span class="cursor-p" @click="greaterDust = getGreaterDust()">{{$t('blacksmith.max')}}</span>
+                  <span class="cursor-p" @click="greaterDust = 25">{{$t('blacksmith.max')}}</span>
                 </div>
               </div>
 
@@ -412,11 +412,11 @@
                   </div>
                 </div>
                 <div>
-                  <input v-model="powerfulDust" type="range" min="0" :max="getPowerfulDust()" value="0" steps="1">
+                  <input v-model="powerfulDust" type="range" min="0" :max="10" value="0" steps="1">
                 </div>
                 <div>
                   <span>{{powerfulDust}}/{{getPowerfulDust()}}</span>
-                  <span class="cursor-p" @click="powerfulDust = getPowerfulDust()">{{$t('blacksmith.max')}}</span>
+                  <span class="cursor-p" @click="powerfulDust = 10">{{$t('blacksmith.max')}}</span>
                 </div>
               </div>
               <div class="btn-forge">

--- a/frontend/src/views/Blacksmith.vue
+++ b/frontend/src/views/Blacksmith.vue
@@ -372,11 +372,11 @@
                   </div>
                 </div>
                 <div>
-                  <input v-model="lesserDust" type="range" min="0" :max="100" value="0" steps="1">
+                  <input v-model="lesserDust" type="range" min="0" :max="lesserDustReforgeCap" value="0" steps="1">
                 </div>
                 <div>
                   <span>{{lesserDust}}/{{getLesserDust()}}</span>
-                  <span class="cursor-p" @click="lesserDust = 100">{{$t('blacksmith.max')}}</span>
+                  <span class="cursor-p" @click="lesserDust = lesserDustReforgeCap">{{$t('blacksmith.max')}}</span>
                 </div>
               </div>
 
@@ -392,11 +392,11 @@
                   </div>
                 </div>
                 <div>
-                  <input v-model="greaterDust" type="range" min="0" :max="25" value="0" steps="1">
+                  <input v-model="greaterDust" type="range" min="0" :max="greaterDustReforgeCap" value="0" steps="1">
                 </div>
                 <div>
                   <span>{{greaterDust}}/{{getGreaterDust()}}</span>
-                  <span class="cursor-p" @click="greaterDust = 25">{{$t('blacksmith.max')}}</span>
+                  <span class="cursor-p" @click="greaterDust = greaterDustReforgeCap">{{$t('blacksmith.max')}}</span>
                 </div>
               </div>
 
@@ -412,11 +412,11 @@
                   </div>
                 </div>
                 <div>
-                  <input v-model="powerfulDust" type="range" min="0" :max="10" value="0" steps="1">
+                  <input v-model="powerfulDust" type="range" min="0" :max="powerfulDustReforgeCap" value="0" steps="1">
                 </div>
                 <div>
                   <span>{{powerfulDust}}/{{getPowerfulDust()}}</span>
-                  <span class="cursor-p" @click="powerfulDust = 10">{{$t('blacksmith.max')}}</span>
+                  <span class="cursor-p" @click="powerfulDust = powerfulDustReforgeCap">{{$t('blacksmith.max')}}</span>
                 </div>
               </div>
               <div class="btn-forge">
@@ -686,6 +686,9 @@ interface Data {
   lesser: number;
   greater: number;
   powerful: number;
+  lesserDustReforgeCap: number,
+  greaterDustReforgeCap: number,
+  powerfulDustReforgeCap: number,
   activeTab: string;
   ctr: number;
   mintSlippageApproved: boolean;
@@ -743,6 +746,9 @@ export default Vue.extend({
       lesser: 0,
       greater: 0,
       powerful: 0,
+      lesserDustReforgeCap: 100,
+      greaterDustReforgeCap: 25,
+      powerfulDustReforgeCap: 10,
       activeTab: 'forge',
       ctr: 0,
       mintSlippageApproved: false,


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?
Before:
![image](https://user-images.githubusercontent.com/41158626/226433172-73ffbb5d-310b-4b63-bfa8-c9ce4e93b461.png)

After:
![Screenshot from 2023-03-20 19-28-12](https://user-images.githubusercontent.com/41158626/226433314-7057614e-0ad0-47d3-81a1-8f18c9250d9a.png)

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
Closes https://github.com/CryptoBlades/cryptoblades/issues/1830
### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Limit the usable amount of LB/4B & 5B dust when reforging a weapon.
The max button also makes use of the max cap.

The actual issue didn't mention the LB, but the solidity contract shows 100 for LB, so also fixed that so
all three behave "equally".

### Testing

Has been tested by me, test are welcome tho!
