### PR TITLE
Allow pvp characters to be withrawn, when "stuck" in arena.

### DIFF
--- a/contracts/PvpCore.sol
+++ b/contracts/PvpCore.sol
@@ -105,7 +105,7 @@ contract PvpCore is Initializable, AccessControlUpgradeable {
     /// @dev IDs of characters available for matchmaking by tier
     mapping(uint8 => EnumerableSet.UintSet) private _matchableCharactersByTier;
     /// @dev special weapon reroll timestamp
-    mapping(uint256 => uint256) public specialWeaponRerollTimestamp;    
+    mapping(uint256 => uint256) public specialWeaponRerollTimestamp;
     /// @dev owner's address by character ID
     mapping(uint256 => address) private _ownerByCharacter;
 

--- a/contracts/PvpCore.sol
+++ b/contracts/PvpCore.sol
@@ -105,7 +105,7 @@ contract PvpCore is Initializable, AccessControlUpgradeable {
     /// @dev IDs of characters available for matchmaking by tier
     mapping(uint8 => EnumerableSet.UintSet) private _matchableCharactersByTier;
     /// @dev special weapon reroll timestamp
-    mapping(uint256 => uint256) public specialWeaponRerollTimestamp;
+    mapping(uint256 => uint256) public specialWeaponRerollTimestamp;    
     /// @dev owner's address by character ID
     mapping(uint256 => address) private _ownerByCharacter;
 
@@ -129,6 +129,14 @@ contract PvpCore is Initializable, AccessControlUpgradeable {
         uint256 kickedBy,
         uint256 timestamp
     );
+
+    modifier removeCharacterFromExpiredDuel(uint256 characterID) {
+        if (isCharacterInDuel(characterID) && !isCharacterWithinDecisionTime(characterID)) {
+            isDefending[characterID] = true;
+            _duelQueue.remove(characterID);
+        }
+        _;
+    }
 
     modifier characterInArena(uint256 characterID) {
         _characterInArena(characterID);
@@ -273,6 +281,7 @@ contract PvpCore is Initializable, AccessControlUpgradeable {
         external
         isOwnedCharacter(characterID)
         characterInArena(characterID)
+        removeCharacterFromExpiredDuel(characterID)
         characterNotUnderAttack(characterID)
         characterNotInDuel(characterID)
     {

--- a/migrations/214_pvp_arena_character_stuck_in_duel_fix.js
+++ b/migrations/214_pvp_arena_character_stuck_in_duel_fix.js
@@ -1,0 +1,7 @@
+const {upgradeProxy} = require('@openzeppelin/truffle-upgrades');
+
+const PvpCore = artifacts.require("PvpCore");
+
+module.exports = async function (deployer) {
+  await upgradeProxy(PvpCore.address, PvpCore, {deployer});
+};


### PR DESCRIPTION
### All Submissions

* [ ] Can you post a screenshot of your changes (if applicable)?
A screenshot would not give enough information, in my case metamask would already tell me that the transaction would probably fail, which doesn't occur anymore after this change.

### New Feature Submissions

* [ ] Does this relate to an existing issue, or has it been talked about prior to being done (if a major change)?
fixes #1844 

### Notes

Please note, your code must pass all tests and lint checks before it can be merged.

### PR Description

Characters in the arena cannot leave the arena if they where previously defending in a duel (Even though the duel has expired), this cause the character to be stuck preventing the user to withdraw their character(s).

### Testing

Has the code been tested, or does it need double checking?

Yes it has been tested thoroughly by myself, but a second opinion / test would always be nice, but is optional. 
